### PR TITLE
Login redirect

### DIFF
--- a/client/main.jsx
+++ b/client/main.jsx
@@ -2,9 +2,10 @@ import React from 'react';
 import { Meteor } from 'meteor/meteor';
 import { render } from 'react-dom';
 
-import Login      from '../imports/ui/Login.jsx';
-import ClassView  from '../imports/ui/ClassView.jsx';
-import App       from '../imports/ui/App.jsx';
+import Login              from '../imports/ui/Login.jsx';
+import ClassView          from '../imports/ui/ClassView.jsx';
+import App                from '../imports/ui/App.jsx';
+import AuthRedirect       from '../imports/ui/AuthRedirect.jsx';
 
 import { BrowserRouter, Route } from "react-router-dom";
 
@@ -23,6 +24,7 @@ Meteor.startup(() => {
                 <Route name="app" exact path="/" component={ App } />
                 <Route name="admin" exact path="/admin" component={ Login } />
                 <Route name="permalink" exact path="/course/:subject/:number" component={ ClassView } />
+                <Route name="auth" exact path="/auth" component={ AuthRedirect } />
             </div>
         </BrowserRouter>,
         document.getElementById('render-target')

--- a/imports/ui/AuthRedirect.jsx
+++ b/imports/ui/AuthRedirect.jsx
@@ -3,22 +3,19 @@ import PropTypes from 'prop-types';
 import { Redirect } from 'react-router';
 
 /*
-Course Component.
+Auth Redirect Component.
 
-Simple styling component that represents a single course (an li element).
-Used to list courses in the results of a search in SearchBar.
+Component mainly for accepting user redirect from Google and redirecting user back to
+the appropriate class (eg. /course/CS/2110) or admin page (eg. /admin)
 
-If a query is provided as a prop, the component is a seach result, so we underline
-and boldface the query text within the title of the course.
+Saves Google ID Token from URL parameters when Google redirects user back to this page
+(eg. /auth/#id_token=abcd123)
 
-Clicking this component will change the route of the app to render the course's ClassView.
 */
 
 export default class AuthRedirect extends Component {
   constructor(props) {
     super(props);
-
-    // grabs class number and subject from the GET parameters
     
     const google_hash = this.props.location.hash;
     if(google_hash !== ""){
@@ -51,6 +48,5 @@ export default class AuthRedirect extends Component {
   }
 }
 
-// Requres course informaiton (database object) to generate course title, and uses the query to
-// determine styling of output
+// No props needed for this component
 AuthRedirect.propTypes = {};

--- a/imports/ui/AuthRedirect.jsx
+++ b/imports/ui/AuthRedirect.jsx
@@ -1,0 +1,56 @@
+import React, { Component} from 'react';
+import PropTypes from 'prop-types';
+import { Redirect } from 'react-router';
+
+/*
+Course Component.
+
+Simple styling component that represents a single course (an li element).
+Used to list courses in the results of a search in SearchBar.
+
+If a query is provided as a prop, the component is a seach result, so we underline
+and boldface the query text within the title of the course.
+
+Clicking this component will change the route of the app to render the course's ClassView.
+*/
+
+export default class AuthRedirect extends Component {
+  constructor(props) {
+    super(props);
+
+    // grabs class number and subject from the GET parameters
+    
+    const google_hash = this.props.location.hash;
+    if(google_hash !== ""){
+      const google_token = google_hash.match(/(?<=id_token=)([^&]+)/)[0];
+      this.saveToken(google_token);
+    }
+  }
+  
+  //Using meteor session to save the token to Session
+  saveToken(token) {
+    Session.setPersistent({"token": token});
+    if (Session.get("token") !== token){
+      console.log("Error saving token to session")
+      return 0;
+    }
+    return 1;
+  }
+  
+  render() {
+    if(Session.get("redirectFrom") === "course"){
+      return <Redirect push to={`/course/${Session.get("review_major")}/${Session.get("review_num")}`}></Redirect>
+    }
+    else if(Session.get("redirectFrom") === "admin"){
+      return <Redirect push to={"/admin"}></Redirect>
+    }
+    else{
+      return <Redirect push to={"/"}></Redirect>
+    }
+    
+  }
+}
+
+// Requres course informaiton (database object) to generate course title, and uses the query to
+// determine styling of output
+AuthRedirect.propTypes = {};

--- a/imports/ui/CUreviewsGoogleLogin.jsx
+++ b/imports/ui/CUreviewsGoogleLogin.jsx
@@ -25,10 +25,13 @@ export default class CUreviewsGoogleLogin extends Component {
     this.responseGoogle.bind(this);
     this.saveRedirectToSession.bind(this);
     this.getRedirectURI.bind(this);
+    
+    //Save redirect page
+    //Will be either "admin" or "course"
     this.saveRedirectToSession(this.props.redirectFrom);
   }
   
-  //Using meteor session to save the token to Session
+  //Using meteor session to save the redirct page to Session
   saveRedirectToSession(from) {
     Session.setPersistent({"redirectFrom": from});
     if (Session.get("redirectFrom") !== from){

--- a/imports/ui/CUreviewsGoogleLogin.jsx
+++ b/imports/ui/CUreviewsGoogleLogin.jsx
@@ -22,24 +22,31 @@ export default class CUreviewsGoogleLogin extends Component {
       lastVerification: (new Date().getTime()) - 5000
     }
 
-    this.responseGoogle.bind(this)
+    this.responseGoogle.bind(this);
+    this.saveRedirectToSession.bind(this);
+    this.saveRedirectToSession(this.props.redirectFrom);
   }
-
-  // // some function used in the app
-  // func1(value) {
-  // 
-  // }
-  // 
-  // // another function used in the app. If these get to long, move to a new
-  // // file under the /js folder named Template.js.
-  // func2(value) {
-  // 
-  // }
-
+  
+  //Using meteor session to save the token to Session
+  saveRedirectToSession(from) {
+    Session.setPersistent({"redirectFrom": from});
+    if (Session.get("redirectFrom") !== from){
+      console.log("Error saving redirectFrom to session");
+      return 0;
+    }
+    return 1;
+  }
+  
+  //This callback function is only called when Google Log-In uses a pop-up.  We now use a redirect
+  // instead.  Therefore this callback is never used/called but I'll leave here for furture reference.
+  // Previously called by adding: onSuccess={this.responseGoogle.bind(this)}
+  // as a prop passed into <GoogleLogin> component below.
   responseGoogle = (response) => {
     const token = response.tokenId;
+    console.log(token);
     if (token){
       if (this.saveToken(token) === 1){
+        console.log(Session.get("token"));
         // console.log("Succesfully saved token to session");
       } else{
         console.log("Error saving token");
@@ -49,85 +56,8 @@ export default class CUreviewsGoogleLogin extends Component {
     }
     else{
       this.props.onFailureFunction(response);
-    }
-    
+    }  
   }
-
-  //Checks database for user with given netId. If user does not exits,
-  //creates new user from [response], inserts into database, and returns the new user.
-  retrieveUser = (response) =>{
-    //Get netID from response and look for in database
-    const profile=response.profileObj;
-    const netId=profile.email.split("@")[0];
-    let currentUser;
-    Meteor.call('getUserByNetId', netId, (error, result) =>{
-      if(!error || result===1){
-        currentUser=result;
-
-        // Create new user from profile of response if user does not exist yet
-        if (currentUser == null) {
-          let newUser={
-            firstName: profile.givenName,
-            lastName: profile.familyName,
-            netId: netId,
-            affiliation: null,
-            token: response.tokenId,
-            privilege: "regular"
-          }
-          //Insert the new user into the the database
-          Meteor.call('insertUser', newUser, (error, result) =>{
-            if(!error || result===1){
-              currentUser=newUser;
-
-              //Gets the new user from the database. This is done so that
-              //the Mongo generated _id is included in the object
-              Meteor.call('getUserByNetId', netId, (error, result) =>{
-                if(!error || result===1){
-                  currentUser=result;
-                  return currentUser;
-                }
-                else{
-                  console.log(error);
-                }
-              }
-              );
-            }
-            else{
-              console.log(error);
-            }
-          }
-          );
-      
-        }
-        return currentUser;
-      }
-      else{
-        console.log(error);
-      }
-    }
-    );
-  }
-  
-  //Using meteor session to save the netID and token
-  //Saves user's netID and token from response to Session
-  saveToken(token) {
-    // console.log("This is the token in saveToken");
-    // console.log(token);
-    Session.setPersistent({"token": token});
-    if (Session.get("token") != token){
-      console.log("Error saving token to session")
-      return 0;
-    }
-    // console.log("This is the session after saving token");
-    // console.log(Session);
-    return 1;
-  }
-  
-  // // function that specifically renders HTML or another component. Keep these
-  // // at the bottom of the list of functions, closer to the final render
-  // renderElement() {
-  // 
-  // }
   
   render() {
     return (
@@ -144,8 +74,8 @@ export default class CUreviewsGoogleLogin extends Component {
               }, this.props.waitTime)
                : 1 }</script>
           )}
-          onSuccess={this.responseGoogle.bind(this)}
-          onFailure={this.responseGoogle.bind(this)}
+          uxMode="redirect"
+          redirectUri='http://localhost:3000/auth/'
         />
       </div>
     );
@@ -159,5 +89,6 @@ export default class CUreviewsGoogleLogin extends Component {
 // describe props
 CUreviewsGoogleLogin.propTypes = {
   executeLogin:PropTypes.bool,
-  waitTime:PropTypes.string
+  waitTime:PropTypes.string,
+  redirectFrom:PropTypes.string
 };

--- a/imports/ui/CUreviewsGoogleLogin.jsx
+++ b/imports/ui/CUreviewsGoogleLogin.jsx
@@ -24,6 +24,7 @@ export default class CUreviewsGoogleLogin extends Component {
 
     this.responseGoogle.bind(this);
     this.saveRedirectToSession.bind(this);
+    this.getRedirectURI.bind(this);
     this.saveRedirectToSession(this.props.redirectFrom);
   }
   
@@ -59,6 +60,13 @@ export default class CUreviewsGoogleLogin extends Component {
     }  
   }
   
+  getRedirectURI(){
+    if(window.location.host.includes("localhost")){
+      return "http://" + window.location.host + "/auth/"
+    }
+      return "https://" + window.location.host + "/auth/"
+  }
+  
   render() {
     return (
       <div>
@@ -75,7 +83,7 @@ export default class CUreviewsGoogleLogin extends Component {
                : 1 }</script>
           )}
           uxMode="redirect"
-          redirectUri='http://localhost:3000/auth/'
+          redirectUri={this.getRedirectURI()}
         />
       </div>
     );

--- a/imports/ui/Form.jsx
+++ b/imports/ui/Form.jsx
@@ -133,6 +133,10 @@ export default class Form extends Component {
     this.workloadSlider.current.value = 3;
     this.dropdownHeight = this.dropdownMenu.current.clientHeight + 15;
     this.toggleDropdown(); //Open review dropdown when page loads
+    
+    //If there is currently a review stored in the session, this means that we have
+    // come back from the authentication page
+    // In this case, submit the review
     if(Session.get("review") != ""){
       this.submitReview();
     }
@@ -190,6 +194,7 @@ export default class Form extends Component {
         };
         this.setState({"review" : newReview})
         
+        // Call save review object to session so that it is not lost when authenicating (redirecting)
         this.saveReviewToSession(newReview);
         
         this.show();
@@ -211,6 +216,7 @@ export default class Form extends Component {
         this.profSelect.current.value = "none";
         this.toggleDropdown(); //Close the review dropdown when page loads
     
+        // Reset review info to default after review submission
         this.setState(this.defaultState);
         Session.setPersistent({"review": ""});
         Session.setPersistent({"review_major": ""});
@@ -225,7 +231,6 @@ export default class Form extends Component {
         Session.setPersistent({"review": ""});
         Session.setPersistent({"review_major": ""});
         Session.setPersistent({"review_num": ""});
-        // this.setState({message: "A error occurred. Please try again."});
         this.hide();
       }
     });

--- a/imports/ui/Form.jsx
+++ b/imports/ui/Form.jsx
@@ -73,6 +73,7 @@ export default class Form extends Component {
     this.toggleDropdown.bind(this)
     this.submitReview = this.submitReview.bind(this)
     this.submitError = this.submitError.bind(this)
+    this.saveReviewToSession = this.saveReviewToSession.bind(this)
     this.hide = this.hide.bind(this)
     this.show = this.show.bind(this)
   }
@@ -132,6 +133,9 @@ export default class Form extends Component {
     this.workloadSlider.current.value = 3;
     this.dropdownHeight = this.dropdownMenu.current.clientHeight + 15;
     this.toggleDropdown(); //Open review dropdown when page loads
+    if(Session.get("review") != ""){
+      this.submitReview();
+    }
   }
 
   // Called each time this component receieves new props.
@@ -143,6 +147,22 @@ export default class Form extends Component {
       this.workloadSlider.current.value = 3;
       this.setState(this.defaultState);
     }
+  }
+
+  //Saves review input to session before redirecting to Google Authentication
+  saveReviewToSession(review) {
+    Session.setPersistent({"review": review});
+    Session.setPersistent({"review_major": this.props.course.classSub.toUpperCase()});
+    Session.setPersistent({"review_num": this.props.course.classNum});
+    if (!(_.isEqual(Session.get("review"),review)
+        && Session.get("review_major") === this.props.course.classSub.toUpperCase()
+        && Session.get("review_num") === this.props.course.classNum)){
+      console.log("Error saving review data to session");
+      return 0;
+    }
+    // console.log("This is the session after saving token");
+    // console.log(Session);
+    return 1;
   }
 
   // Form submission handler. This will either add the review to the database
@@ -170,13 +190,18 @@ export default class Form extends Component {
         };
         this.setState({"review" : newReview})
         
+        this.saveReviewToSession(newReview);
+        
         this.show();
     }
   }
 
   submitReview() {
-    // call the api insert function
-    Meteor.call('insert', Session.get("token"), this.state.review, this.props.course._id, (error, result) => {
+    // Call the API insert function
+    Meteor.call('insert', Session.get("token"), 
+                Session.get("review") != "" ? Session.get("review") : this.state.review, 
+                this.props.course._id, 
+                (error, result) => {
       // if (!error && result === 1) {
       if (error || result === 1) {
         // Success, so reset form
@@ -187,6 +212,9 @@ export default class Form extends Component {
         this.toggleDropdown(); //Close the review dropdown when page loads
     
         this.setState(this.defaultState);
+        Session.setPersistent({"review": ""});
+        Session.setPersistent({"review_major": ""});
+        Session.setPersistent({"review_num": ""});
         this.hide();
         
         Bert.alert('Thanks! Your review is currently pending approval.');
@@ -194,7 +222,10 @@ export default class Form extends Component {
         // error, alert user
         console.log(error);
         Bert.alert("An unknown error occured, please try again.", "danger");
-        this.setState({message: "A error occurred. Please try again."});
+        Session.setPersistent({"review": ""});
+        Session.setPersistent({"review_major": ""});
+        Session.setPersistent({"review_num": ""});
+        // this.setState({message: "A error occurred. Please try again."});
         this.hide();
       }
     });
@@ -411,9 +442,8 @@ export default class Form extends Component {
                 </p>
                 <CUreviewsGoogleLogin 
                       executeLogin={this.state.visible}
-                      waitTime="3000"  
-                      onSuccessFunction={this.submitReview}
-                      onFailureFunction={this.submitError} />
+                      waitTime="3000"
+                      redirectFrom="course" />
               </div>
             </div>
             

--- a/imports/ui/Login.jsx
+++ b/imports/ui/Login.jsx
@@ -22,22 +22,34 @@ export default class Login extends Component {
     // input elements are controlled components. Store the value of the
     // user's input password and its validation state.
     this.state = {
-      pass: "",
-      message: ""
+      message: "",
+      executeLogin: false
     };
 
     this.defaultState = this.state;
-    this.changeSession = this.changeSession.bind(this)
   }
-
-  changeSession(){
-    console.log("Change session");
-    Session.set("adminlogin", true);
-    this.setState({"pass" : "two"});
+  
+  componentWillMount() {
+    // The following is used to show admin panel if a user's token is found to be an admin
+    if(Session.get("token") != ""){
+      Meteor.call('tokenIsAdmin', Session.get("token"), (error, result) => {
+        if(result){
+          Session.set("adminlogin", true);
+          this.setState({executeLogin: false}); //This isn't necessary as it should alrady be allFalse
+                                                // but it is used to refresh the render()
+        }
+        else{
+          this.setState({executeLogin: true});
+        }
+      });
+    }
+    else{
+      this.setState({executeLogin: true});
+    }
   }
 
   render() {
-    // if password was valid, show admin interface, otherwise ask for the password.
+    // If Google login was valid, show admin interface.
     if (Session.get("adminlogin") === true) {
       return (
         <Admin />
@@ -51,11 +63,10 @@ export default class Login extends Component {
                 <h3 className="panel-title">Please wait to be authenticated</h3>
               </div>
               <div className="panel-body">
-                <CUreviewsGoogleLogin 
-                      executeLogin={true} 
-                      waitTime="1500"
-                      onSuccessFunction={this.changeSession}
-                      onFailureFunction={this.responseGoogle} />
+              <CUreviewsGoogleLogin 
+                    executeLogin={this.state.executeLogin}
+                    waitTime="1500"
+                    redirectFrom="admin" />
               </div>
             </div>
           </div>

--- a/server/methods.js
+++ b/server/methods.js
@@ -65,12 +65,12 @@ Meteor.methods({
   //Upon success returns 1, else returns 0
   insertUser: function (googleObject) {
     //Check user object has all required fields
-    if (googleObject.given_name != null
-      && googleObject.family_name != null
-      && googleObject.email.replace("@cornell.edu", "") != null) {
+    if (googleObject.email.replace("@cornell.edu", "") != null) {
       const newUser = {
-        firstName: googleObject.given_name,
-        lastName: googleObject.family_name,
+        // Check to see if Google returns first and last name
+        // If not, insert empty string to database
+        firstName: googleObject.given_name ? googleObject.given_name : "",
+        lastName: googleObject.family_name ? googleObject.family_name : "",
         netId: googleObject.email.replace("@cornell.edu", ""),
         affiliation: null,
         token: null,

--- a/server/methods.js
+++ b/server/methods.js
@@ -49,6 +49,8 @@ Meteor.methods({
           return 0; //fail
         }
       } else {
+        console.log(review);
+        console.log(classId);
         console.log("Error: Some review values are null");
         return 0; //fail
       }
@@ -63,6 +65,8 @@ Meteor.methods({
   //Upon success returns 1, else returns 0
   insertUser: function (googleObject) {
     //Check user object has all required fields
+    console.log("googleObject");
+    console.log(googleObject);
     if (googleObject.given_name != null
       && googleObject.family_name != null
       && googleObject.email.replace("@cornell.edu", "") != null) {
@@ -82,7 +86,8 @@ Meteor.methods({
           Students.insert(newUser);
           return 1; //success
         } catch (error) {
-          console.log(error)
+          console.log("Error: In inserting Student");
+          console.log(error);
           return 0; //fail
         }
       }
@@ -457,12 +462,22 @@ Meteor.methods({
         console.log("Token was undefined in getVerificationTicket")
         return 0; // Token was undefined
       }
+      client.generateAuthUrl({
+      scope: [
+        'https://www.googleapis.com/auth/plus.login',
+        'https://www.googleapis.com/auth/plus.me',
+        'https://www.googleapis.com/auth/userinfo.email',
+        'https://www.googleapis.com/auth/userinfo.profile',
+        'email'
+      ]});
       const ticket = await client.verifyIdToken({
         idToken: token,
         audience: "836283700372-msku5vqaolmgvh3q1nvcqm3d6cgiu0v1.apps.googleusercontent.com",  // Specify the CLIENT_ID of the app that accesses the backend
         // Or, if multiple clients access the backend:
         //[CLIENT_ID_1, CLIENT_ID_2, CLIENT_ID_3]
       });
+      console.log("ticket");
+      console.log(ticket);
       return ticket.getPayload();
       // console.log(ticket);
       const payload = ticket.getPayload();
@@ -481,6 +496,7 @@ Meteor.methods({
       return valid_email;
 
     } catch (e) {
+      console.log("Error: at getVerificationTicket");
       console.log(e);
       return false;
     }

--- a/server/methods.js
+++ b/server/methods.js
@@ -23,6 +23,8 @@ Meteor.methods({
       return 0; // Token was undefined
     }
     const ticket = Meteor.call('getVerificationTicket', token);
+    // console.log("ticket");
+    // console.log(ticket);
     Meteor.call('insertUser', ticket);
     if (ticket.hd === "cornell.edu"){
       if (review.text !== null && review.diff !== null && review.rating !== null && review.workload !== null && review.professors !== null && classId !== undefined && classId !== null) {
@@ -49,8 +51,6 @@ Meteor.methods({
           return 0; //fail
         }
       } else {
-        console.log(review);
-        console.log(classId);
         console.log("Error: Some review values are null");
         return 0; //fail
       }
@@ -65,8 +65,6 @@ Meteor.methods({
   //Upon success returns 1, else returns 0
   insertUser: function (googleObject) {
     //Check user object has all required fields
-    console.log("googleObject");
-    console.log(googleObject);
     if (googleObject.given_name != null
       && googleObject.family_name != null
       && googleObject.email.replace("@cornell.edu", "") != null) {
@@ -97,7 +95,7 @@ Meteor.methods({
     }
     else {
       //error handling
-      console.log("Some user values are null")
+      console.log("Some user values are null in insertUser");
       return 0; //fail
     }
   },
@@ -462,22 +460,12 @@ Meteor.methods({
         console.log("Token was undefined in getVerificationTicket")
         return 0; // Token was undefined
       }
-      client.generateAuthUrl({
-      scope: [
-        'https://www.googleapis.com/auth/plus.login',
-        'https://www.googleapis.com/auth/plus.me',
-        'https://www.googleapis.com/auth/userinfo.email',
-        'https://www.googleapis.com/auth/userinfo.profile',
-        'email'
-      ]});
       const ticket = await client.verifyIdToken({
         idToken: token,
         audience: "836283700372-msku5vqaolmgvh3q1nvcqm3d6cgiu0v1.apps.googleusercontent.com",  // Specify the CLIENT_ID of the app that accesses the backend
         // Or, if multiple clients access the backend:
         //[CLIENT_ID_1, CLIENT_ID_2, CLIENT_ID_3]
       });
-      console.log("ticket");
-      console.log(ticket);
       return ticket.getPayload();
       // console.log(ticket);
       const payload = ticket.getPayload();


### PR DESCRIPTION
### Summary <!-- Required -->

Google Login had become broken on Safari after enforcing HTTPS.  This was because Safari blocks the log-in pop-up by default.  In this commit, I have re-arranged the log-in workflow to use a series of redirects instead, allowing it to work with pop-up blockers and be more mobile-friendly.

### Test Plan <!-- Required -->

<!-- Provide screenshots or point out the additional unit tests -->
Tested locally and will be testing in review app.


### Notes <!-- Optional -->

<!--- List any important or subtle points, future considerations, or other items of note. -->
TODO:

This breaks adding users to the database when they update a review.  Very specific problem that will look to fix soon.  Essentially, the problem now is that since we redirect instead of use a callback function, we are not getting user's first and last name back from Google for some reason.
