### PR TITLE
Safari fix

### DIFF
--- a/imports/ui/AuthRedirect.jsx
+++ b/imports/ui/AuthRedirect.jsx
@@ -19,7 +19,7 @@ export default class AuthRedirect extends Component {
     
     const google_hash = this.props.location.hash;
     if(google_hash !== ""){
-      const google_token = google_hash.match(/(?=id_token\=)([^&]+)/)[0].split("=")[1];
+      const google_token = google_hash.match(/(?=id_token=)([^&]+)/)[0].split("=")[1];
       this.saveToken(google_token);
     }
   }

--- a/imports/ui/AuthRedirect.jsx
+++ b/imports/ui/AuthRedirect.jsx
@@ -19,7 +19,7 @@ export default class AuthRedirect extends Component {
     
     const google_hash = this.props.location.hash;
     if(google_hash !== ""){
-      const google_token = google_hash.match(/(?<=id_token=)([^&]+)/)[0];
+      const google_token = google_hash.match(/(?=id_token\=)([^&]+)/)[0].split("=")[1];
       this.saveToken(google_token);
     }
   }


### PR DESCRIPTION
### Summary <!-- Required -->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Itemize bug fixes, new features, and other changes -->
<!-- Feel free to break this into sub-sections, i.e. features, fixes, etc. -->
<!-- Some examples are shown below. -->

Fixes issue with regular expression support on Safari.  Problem was that Safari doesn't support "negative lookbehind" in regex's.  Changed to more supported "positive lookahead"

### Test Plan <!-- Required -->

Tested on local Safari, will test on staging app and Safari mobile.

