### PR TITLE
Changed the course a review from pop-up is submitted for to depend on session, not props

### DIFF
--- a/imports/ui/ClassView.jsx
+++ b/imports/ui/ClassView.jsx
@@ -171,7 +171,7 @@ export class ClassView extends Component {
                 <button className="popup-button-center" onClick={this.togglePopupForm.bind(this)}>
                 Leave a Review<i className="popup-arrow"></i>
                 </button>
-                <Form inUse={this.state.popUpVisible} searchBar={true} query={this.state.query} queryFunc={this.updateQuery} course={this.state.selectedClass} />
+                <Form searchBar={true} inUse={this.state.popUpVisible} query={this.state.query} queryFunc={this.updateQuery} course={this.state.selectedClass} />
               </div>
             </div>
             

--- a/imports/ui/ClassView.jsx
+++ b/imports/ui/ClassView.jsx
@@ -51,10 +51,13 @@ export class ClassView extends Component {
       popupPos: "hidden",
     };
 
+    this.firstLoad = true;
+    
     this.togglePopupForm.bind(this);
     this.hidePopup = this.hidePopup.bind(this);
     this.showPopup = this.showPopup.bind(this);
     this.decidePopup = this.decidePopup.bind(this);
+    this.updateCurrentClass = this.updateCurrentClass.bind(this);
     this.decidePopup();
   }
 
@@ -64,14 +67,8 @@ export class ClassView extends Component {
   //   window.location = "http://aqueous-river.herokuapp.com/saml/auth?persist=" + encodeURIComponent("http://localhost:3000/auth") +"&redirect=" + encodeURIComponent("http://localhost:3000/app");
   // }
 
-
-
-  // Once the component loads, the constructor will have added the GET variables to the local state.
-  // Use the get variables to search the local Classes database for a class with the
-  // requested subject and course number. Update the local state accordingly.
-  componentWillMount() {
-
-    Meteor.call("getCourseByInfo", this.state.number, this.state.subject, (err, selectedClass) => {
+  updateCurrentClass(classNumber, classSubject){
+    Meteor.call("getCourseByInfo", classNumber, classSubject, (err, selectedClass) => {
       if (!err && selectedClass) {
         // Save the Class object that matches the request
         this.setState({
@@ -80,13 +77,34 @@ export class ClassView extends Component {
       }
       else {
         // No class matches the request.
-        console.log("no");
+        console.log("No match");
         this.setState({
           classDoesntExist: true
         });
       }
     });
-
+  }
+  
+  componentDidUpdate(prevProps){
+    //if this component receives new props from the Redirect, it resets its state so that it can render/mount
+    //a new ClassView component with the new props
+    const number = this.props.match.params.number;
+    const subject = this.props.match.params.subject.toLowerCase();
+    
+    if(prevProps.match.params.number !== number
+        && prevProps.match.params.subject !== subject
+        || this.firstLoad){
+      this.setState({
+        number: number,
+        subject: subject,
+        selectedClass: null,
+        classDoesntExist: false,
+        popUpVisible: false,
+        popupPos: "hidden",
+      });
+      this.firstLoad = false;
+      this.updateCurrentClass(number, subject);
+    }
   }
   
   getPopUpCourseOptions() {

--- a/imports/ui/ClassView.jsx
+++ b/imports/ui/ClassView.jsx
@@ -50,7 +50,8 @@ export class ClassView extends Component {
       popUpVisible: false,
       popupPos: "hidden",
     };
-
+    
+    //Used to prevent endless reloading in componentDidUpdate
     this.firstLoad = true;
     
     this.togglePopupForm.bind(this);
@@ -67,6 +68,8 @@ export class ClassView extends Component {
   //   window.location = "http://aqueous-river.herokuapp.com/saml/auth?persist=" + encodeURIComponent("http://localhost:3000/auth") +"&redirect=" + encodeURIComponent("http://localhost:3000/app");
   // }
 
+  // Once the component loads, make a call to the backend for class object.
+  // Update the local state accordingly.  Called from componentDidUpdate()
   updateCurrentClass(classNumber, classSubject){
     Meteor.call("getCourseByInfo", classNumber, classSubject, (err, selectedClass) => {
       if (!err && selectedClass) {

--- a/imports/ui/Form.jsx
+++ b/imports/ui/Form.jsx
@@ -221,10 +221,11 @@ export default class Form extends Component {
     // Call the API insert function
     Meteor.call('insert', Session.get("token"), 
                 Session.get("review") != "" ? Session.get("review") : this.state.review, 
-                !this.props.searchBar ? this.props.course._id : Session.get("courseId"), 
+                !Session.get("courseId") ? this.props.course._id : Session.get("courseId"), 
                 (error, result) => {
       // if (!error && result === 1) {
       if (error || result === 1) {
+        console.log("course id: "+Session.get("courseId"));
         // Success, so reset form
         this.ratingSlider.current.value = 3;
         this.diffSlider.current.value = 3;


### PR DESCRIPTION
The review form in the "Leave a review" pop-up had previously determined if it should submit a review for the course in classView or the course selected in the pop-up by "searchBar" prop. This pull request changes this decision to be made on whether session's "courseId" is undefined or not.

The "courseId" is set in a handler in the pop-up's search bar and set to undefined after the review is submitted, ensuring this does not interfere with regular reviews.

Also fixes bug where "enter" key when searching in a classview does not actually change the page to be the new class.

