### PR TITLE
Add support for access-control-allow-origin header in API

### DIFF
--- a/.meteor/packages
+++ b/.meteor/packages
@@ -31,3 +31,4 @@ underscore
 u2622:persistent-session
 force-ssl
 simple:rest
+simple:json-routes

--- a/imports/api/dbDefs.js
+++ b/imports/api/dbDefs.js
@@ -9,7 +9,14 @@ try {
   console.log(e);
 }
 
-  
+JsonRoutes.setResponseHeaders({
+  "Cache-Control": "no-store",
+  "Pragma": "no-cache",
+  "Access-Control-Allow-Origin": "*",
+  "Access-Control-Allow-Methods": "GET, PUT, POST, DELETE, OPTIONS",
+  "Access-Control-Allow-Headers": "Content-Type, Authorization, X-Requested-With"
+});  
+
 /*
 
  Database definitions file. Defines all collections in the local database,


### PR DESCRIPTION
### Summary <!-- Required -->

This PR fixes the issue that the API does not return a `access-control-allow-origin` header and therefore does not allow API requests from other applications.

### Test Plan <!-- Required -->

Tested locally for the appearance of `access-control-allow-origin` header in Postman, will test in dev site, then deploy to prod.
