### PR TITLE
Fix bug causing crash in API

### DIFF
--- a/imports/api/dbDefs.js
+++ b/imports/api/dbDefs.js
@@ -9,13 +9,18 @@ try {
   console.log(e);
 }
 
-JsonRoutes.setResponseHeaders({
-  "Cache-Control": "no-store",
-  "Pragma": "no-cache",
-  "Access-Control-Allow-Origin": "*",
-  "Access-Control-Allow-Methods": "GET, PUT, POST, DELETE, OPTIONS",
-  "Access-Control-Allow-Headers": "Content-Type, Authorization, X-Requested-With"
-});  
+try {
+  JsonRoutes.setResponseHeaders({
+    "Cache-Control": "no-store",
+    "Pragma": "no-cache",
+    "Access-Control-Allow-Origin": "*",
+    "Access-Control-Allow-Methods": "GET, PUT, POST, DELETE, OPTIONS",
+    "Access-Control-Allow-Headers": "Content-Type, Authorization, X-Requested-With"
+  });  
+} catch (e) {
+  console.log(e);
+}
+
 
 /*
 


### PR DESCRIPTION
### Summary <!-- Required -->

Fixes the crashing site.  Bug was caused by using a new Meteor package `JsonRoutes` while not being able to explicitly import it (because it's a meteor package and not an NPM one).  In the future we are going to migrate to NPM packages only.

### Test Plan <!-- Required -->

Tested locally, will test in dev site, then confirm on prod.
