### PR TITLE
Database update

### DIFF
--- a/imports/api/dbDefs.js
+++ b/imports/api/dbDefs.js
@@ -101,6 +101,8 @@ Reviews.schema = new SimpleSchema({
     // The full functional code for counting reviews can be found on the following branch:
     // review-counting-feature
     // memberReferral: { type: String, optional: true }, // DTI member referral for review contest
+    virtual: { type: Boolean }, // whether or not this review is for a class was taught virtually at least part of the time
+                                // added due to COVID-19 situation. Possible future compatility if/when Cornell adds more virtual options
 });
 
 /* # Validation Collection.

--- a/imports/ui/Review.jsx
+++ b/imports/ui/Review.jsx
@@ -157,6 +157,7 @@ export default class Review extends Component {
 
             <p className={this.review_number_label_class}>Workload</p>
 
+            <p className={this.review_number_label_class}>{review.virtual ? "VIRTUAL!": ""}</p>
           </div>
           <div className="row noLeftRightSpacing">
             <div className="col-md-2 col-sm-2 col-xs-2 noLeftRightSpacing review-padding-left">

--- a/imports/ui/js/CourseCard.js
+++ b/imports/ui/js/CourseCard.js
@@ -134,7 +134,7 @@ export function getGaugeValues(allReviews) {
   } else if (ratingRatioVirtual == 0) {
     newState.rating = ratingRatioNormal.toFixed(1);
   } else {
-    newState.rating = ((ratingRatioNormal + virtualWeightFactor * ratingRatioVirtual) / (1 + virtualWeightFactor)).toFixed(1);;
+    newState.rating = ((ratingRatioNormal + virtualWeightFactor * ratingRatioVirtual) / (1 + virtualWeightFactor)).toFixed(1);
   }
 
   // these behave the same as their counterparts for ratings
@@ -148,7 +148,7 @@ export function getGaugeValues(allReviews) {
   } else if (diffRatioVirtual == 0) {
     newState.diff = diffRatioNormal.toFixed(1);
   } else {
-    newState.diff = ((diffRatioNormal + virtualWeightFactor * diffRatioVirtual) / (1 + virtualWeightFactor)).toFixed(1);;
+    newState.diff = ((diffRatioNormal + virtualWeightFactor * diffRatioVirtual) / (1 + virtualWeightFactor)).toFixed(1);
   }
 
   // these behave the same as their counterparts for ratings

--- a/imports/ui/js/CourseCard.js
+++ b/imports/ui/js/CourseCard.js
@@ -67,85 +67,128 @@ export function getCrossListOR(course){
 // submitted for this class. Return values for the average difficulty, quality,
 // and madatory/not mandatory status.
 export function getGaugeValues(allReviews) {
-  const newState = {};
-  //create initial variables
-  let sumRating = 0;
-  let sumDiff = 0;
-  let sumWork = 0;
+  // how much should we factor in virtual reviews? Weighted, 0-1, where 1 is as much a regular reviews
+  const virtualWeightFactor = 0.5;
 
-  let countRatingAndDiff = 0;
-  let countWork = 0;
+  const newState = {};
+  // create summation variables for reviews
+  let sumRatingNormal = 0;
+  let sumDiffNormal = 0;
+  let sumWorkNormal = 0;
+
+  let sumRatingVirtual = 0;
+  let sumDiffVirtual = 0;
+  let sumWorkVirtual = 0;
+
+  // create size counting variables
+  let countRatingAndDiffNormal = 0;
+  let countWorkNormal = 0;
+
+  let countRatingAndDiffVirtual = 0;
+  let countWorkVirtual = 0;
 
   allReviews.forEach(function(review) {
     if(review){
-      countRatingAndDiff++;
-      sumDiff += Number(review["difficulty"]);
-      if(review["rating"] !== undefined){
-        sumRating += Number(review["rating"]);
-      }
-      else{
-        sumRating += Number(review["quality"]);
-      }
-      if (review["workload"] != undefined) {
-        countWork++;
-        sumWork += Number(review["workload"]);
+      if (review.virtual) {
+        countRatingAndDiffVirtual++;
+        sumDiffVirtual += Number(review["difficulty"]);
+        if(review["rating"] !== undefined){
+          sumRatingVirtual += Number(review["rating"]);
+        } else {
+          sumRatingVirtual += Number(review["quality"]);
+        }
+        if (review["workload"] != undefined) {
+          countWorkVirtual++;
+          sumWorkVirtual += Number(review["workload"]);
+        }
+      } else {
+        countRatingAndDiffNormal++;
+        sumDiffNormal += Number(review["difficulty"]);
+        if(review["rating"] !== undefined){
+          sumRatingNormal += Number(review["rating"]);
+        } else {
+          sumRatingNormal += Number(review["quality"]);
+        }
+
+        if (review["workload"] != undefined) {
+          countWorkNormal++;
+          sumWorkNormal += Number(review["workload"]);
+        }
       }
     }
-    
-
   });
 
-  //Update the gauge variable values for rating, difficulty, and workload using averages
-  //Fixed to 1 decimal place
-  
-  if(countRatingAndDiff > 0){
-    newState.rating = (sumRating/countRatingAndDiff).toFixed(1); //out of 5
-    newState.diff = (sumDiff/countRatingAndDiff).toFixed(1); //out of 5
-  }
-  else{
+  // a division function for which divide by 0 is defined to return 0
+  // allows us to optimize the following code
+  let safe_divide = (a, b) => (b == 0 ? 0 : a / b);
+
+  // we know that if these are 0, then there must not be reviews of that type
+  // why? because the minimum rating that anyone can give is 1!
+  const ratingRatioNormal = safe_divide(sumRatingNormal, countRatingAndDiffNormal);
+  const ratingRatioVirtual = safe_divide(sumRatingVirtual, countRatingAndDiffVirtual);
+
+  if (ratingRatioNormal == 0 && ratingRatioVirtual == 0) {
     newState.rating = "-";
+  } else if (ratingRatioNormal == 0) {
+    newState.rating = ratingRatioVirtual.toFixed(1);
+  } else if (ratingRatioVirtual == 0) {
+    newState.rating = ratingRatioNormal.toFixed(1);
+  } else {
+    newState.rating = ((ratingRatioNormal + virtualWeightFactor * ratingRatioVirtual) / (1 + virtualWeightFactor)).toFixed(1);;
+  }
+
+  // these behave the same as their counterparts for ratings
+  const diffRatioNormal = safe_divide(sumDiffNormal, countRatingAndDiffNormal);
+  const diffRatioVirtual = safe_divide(sumDiffVirtual, countRatingAndDiffVirtual);
+
+  if (diffRatioNormal == 0 && diffRatioVirtual == 0) {
     newState.diff = "-";
-  }
-  
-  if(countWork > 0){
-    newState.workload = (sumWork/countWork).toFixed(1); //out of 5
-  }
-  else{
-    newState.workload = "-";
+  } else if (diffRatioNormal == 0) {
+    newState.diff = diffRatioVirtual.toFixed(1);
+  } else if (diffRatioVirtual == 0) {
+    newState.diff = diffRatioNormal.toFixed(1);
+  } else {
+    newState.diff = ((diffRatioNormal + virtualWeightFactor * diffRatioVirtual) / (1 + virtualWeightFactor)).toFixed(1);;
   }
 
+  // these behave the same as their counterparts for ratings
+  const workloadRatioNormal = safe_divide(sumWorkNormal, countWorkNormal);
+  const workloadRatioVirtual = safe_divide(sumWorkVirtual, countWorkVirtual);
 
+  if (workloadRatioNormal == 0 && workloadRatioVirtual == 0) {
+    newState.rating = "-";
+  } else if (workloadRatioNormal == 0) {
+    newState.workload = workloadRatioVirtual.toFixed(1);
+  } else if (workloadRatioVirtual == 0) {
+    newState.workload = workloadRatioNormal.toFixed(1);
+  } else {
+    newState.workload = ((workloadRatioNormal + virtualWeightFactor * workloadRatioVirtual) / (1 + virtualWeightFactor)).toFixed(1);
+  }
 
   //Set gauge color for rating
   if (newState.rating <= 2 ) {
     newState.ratingColor = "#E64458";
-  }
-  else if (newState.rating > 2 && newState.rating < 3.5) {
+  } else if (newState.rating > 2 && newState.rating < 3.5) {
     newState.ratingColor = "#f9cc30";
-  }
-  else {
+  } else {
     newState.ratingColor = "#53B277";
   }
 
   //set gauge color for difficulty
   if (newState.diff <= 2 ) {
     newState.diffColor = "#53B277";
-  }
-  else if (newState.diff > 2 && newState.diff < 3.5) {
+  } else if (newState.diff > 2 && newState.diff < 3.5) {
     newState.diffColor = "#f9cc30";
-  }
-  else {
+  } else {
     newState.diffColor = "#E64458";
   }
   
   //set gauge color for workload
   if (newState.workload <= 2 ) {
     newState.workloadColor = "#53B277";
-  }
-  else if (newState.workload > 2 && newState.workload < 3.5) {
+  } else if (newState.workload > 2 && newState.workload < 3.5) {
     newState.workloadColor = "#f9cc30";
-  }
-  else {
+  } else {
     newState.workloadColor = "#E64458";
   }
   

--- a/imports/ui/js/CourseCard.js
+++ b/imports/ui/js/CourseCard.js
@@ -68,7 +68,7 @@ export function getCrossListOR(course){
 // and madatory/not mandatory status.
 export function getGaugeValues(allReviews) {
   // how much should we factor in virtual reviews? Weighted, 0-1, where 1 is as much a regular reviews
-  const virtualWeightFactor = 0.5;
+  const virtualWeightFactor = 0;
 
   const newState = {};
   // create summation variables for reviews

--- a/server/methods.js
+++ b/server/methods.js
@@ -58,6 +58,7 @@ Meteor.methods({
           reported: 0,
           professors: review.professors,
           likes: 0,
+          virtual: true,
         };
 
         try {
@@ -475,6 +476,9 @@ Meteor.methods({
         fields: { score: { $meta: "textScore" } },
         sort: { score: { $meta: "textScore" } }
       }
+
+      // ensure that there is always an index to search classes by
+      Classes._ensureIndex({classSub: "text", classNum: "text", classTitle: "text"});
       return Classes.find({ "$text": { "$search": keyword } }, options).fetch();
     }
     else return null;
@@ -488,6 +492,9 @@ Meteor.methods({
         fields: { score: { $meta: "textScore" } },
         sort: { score: { $meta: "textScore" } }
       }
+
+      // ensure that there is always an index to search subjects by
+      Subjects._ensureIndex({subShort: "text", subFull: "text"});
       return Subjects.find({ "$text": { "$search": keyword } }, options).fetch();
     }
     else return null;


### PR DESCRIPTION
### Summary

This is a PR to manage the issue of reviews being submitted during the Covid-19 situation perhaps being unrepresentative of the true nature of the class.

As a result, this PR adds some functionality that addresses this issue:
1. Marks new reviews as being 'virtual' (which could be extended to online classes in the future as well)
2. When calculating average scores, allows us to provide a weight on 'virtual' scores from 0 (ignore) to 1 (count the same as a normal review). After some deliberation the team chose weight = 0. This is easily changeable in the future if we change out minds.

### Test Plan 

Tested locally. Chose a new class, added virtual reviews. Confirmed it showed the average of the virtual reviews. Added non-virtual reviews and more virtual reviews. Confirmed it always only showed the average of non-virtual reviews, as per above.

### Notes
A note on behavior: When a class has no non-virtual reviews, the gauges use the averaged virtual score regardless of the relative weighting of virtual to non-virtual reviews. This may be subject to change.
 
This PR also includes a minor bugfix. There was an issue on my machine, where search indices where not defined on the classes and subjects collections. I added some code to ensure that an index is always defined.
