### PR TITLE
Insert previous query to searchbar

### DIFF
--- a/imports/ui/Navbar.jsx
+++ b/imports/ui/Navbar.jsx
@@ -31,7 +31,7 @@ export default class Navbar extends Component {
           </a>
         </div>
         <div className="col navbar-searchbar-container">
-          <SearchBar contrastingResultsBackground={true} isInNavbar={true} />
+          <SearchBar userInput={this.props.userInput} contrastingResultsBackground={true} isInNavbar={true} />
         </div>
       </div>
     )
@@ -40,5 +40,5 @@ export default class Navbar extends Component {
 }
 
 Navbar.propTypes = {
-
+  userInput: PropTypes.string // optional previously entered search term
 };

--- a/imports/ui/Results.jsx
+++ b/imports/ui/Results.jsx
@@ -93,7 +93,7 @@ export class Results extends Component {
   render() {
     return (
       <div className="full-height bg-color">
-        <Navbar />
+        <Navbar userInput={this.props.match.params.input.split("+").join(" ")} />
         <ResultsDisplay courses={this.state.courseList}
         userInput={this.props.match.params.input.split("+").join(" ")}
         loading={this.state.loading} type={this.props.match.params.type}/>

--- a/imports/ui/Results.jsx
+++ b/imports/ui/Results.jsx
@@ -91,11 +91,12 @@ export class Results extends Component {
   }
 
   render() {
+    const userInput = this.props.match.params.input.split("+").join(" ");
     return (
       <div className="full-height bg-color">
-        <Navbar userInput={this.props.match.params.input.split("+").join(" ")} />
+        <Navbar userInput={userInput} />
         <ResultsDisplay courses={this.state.courseList}
-        userInput={this.props.match.params.input.split("+").join(" ")}
+        userInput={userInput}
         loading={this.state.loading} type={this.props.match.params.type}/>
       </div>
     )

--- a/imports/ui/SearchBar.jsx
+++ b/imports/ui/SearchBar.jsx
@@ -297,13 +297,6 @@ export default class SearchBar extends Component {
     }
   }
 
-  // extract the query from what the user asked for
-  extractQuery() {
-    const last_index = window.location.href.lastIndexOf('/') + 1
-    const query = window.location.href.substring(last_index).split("+").join(" ");
-    return query;
-  }
-
   render() {
     if (this.props.isPopup) return (
       <div className="searchbar-popup text-left" >
@@ -316,7 +309,7 @@ export default class SearchBar extends Component {
     else return (
       <div className={"row " + (this.props.contrastingResultsBackground ? "contrasting-result-background" : "")}>
         <div className={"col-lg-12 col-md-12 col-sm-12 searchbar " + (this.props.isInNavbar ? "searchbar-in-navbar" : "")}>
-          <input className="search-text" onKeyUp={this.handleKeyPress} defaultValue = {this.props.isInNavbar ? this.extractQuery() : ""} placeholder={this.props.isInNavbar ? "" : "Search by any keyword e.g. “FWS”, “ECON” or “CS 2110”"} autoComplete="off" />
+          <input className="search-text" onKeyUp={this.handleKeyPress} defaultValue = {this.props.isInNavbar ? (this.props.userInput ? this.props.userInput : "") : ""} placeholder={this.props.isInNavbar ? "" : "Search by any keyword e.g. “FWS”, “ECON” or “CS 2110”"} autoComplete="off" />
 
           <ul className="output" style={this.state.query !== "" ? {} : { display: 'none' }} onKeyPress={this.handleKeyPress} onMouseEnter={this.mouseHover} onMouseLeave={this.mouseLeave}>
             {this.renderResults()}
@@ -336,4 +329,5 @@ SearchBar.propTypes = {
   isPopup: PropTypes.bool, // true if rendered in pop-up
   formPopupHandler: PropTypes.func, //handler to set state for form if in popup
   contrastingResultsBackground: PropTypes.bool, // Used to display contrasting background for search results
+  userInput: PropTypes.string // optional previously entered search term
 };

--- a/imports/ui/SearchBar.jsx
+++ b/imports/ui/SearchBar.jsx
@@ -297,6 +297,13 @@ export default class SearchBar extends Component {
     }
   }
 
+  // extract the query from what the user asked for
+  extractQuery() {
+    const last_index = window.location.href.lastIndexOf('/') + 1
+    const query = window.location.href.substring(last_index).split("+").join(" ");
+    return query;
+  }
+
   render() {
     if (this.props.isPopup) return (
       <div className="searchbar-popup text-left" >
@@ -309,7 +316,7 @@ export default class SearchBar extends Component {
     else return (
       <div className={"row " + (this.props.contrastingResultsBackground ? "contrasting-result-background" : "")}>
         <div className={"col-lg-12 col-md-12 col-sm-12 searchbar " + (this.props.isInNavbar ? "searchbar-in-navbar" : "")}>
-          <input className="search-text" onKeyUp={this.handleKeyPress} placeholder={this.props.isInNavbar ? "" : "Search by any keyword e.g. “FWS”, “ECON” or “CS 2110”"} autoComplete="off" />
+          <input className="search-text" onKeyUp={this.handleKeyPress} defaultValue = {this.props.isInNavbar ? this.extractQuery() : ""} placeholder={this.props.isInNavbar ? "" : "Search by any keyword e.g. “FWS”, “ECON” or “CS 2110”"} autoComplete="off" />
 
           <ul className="output" style={this.state.query !== "" ? {} : { display: 'none' }} onKeyPress={this.handleKeyPress} onMouseEnter={this.mouseHover} onMouseLeave={this.mouseLeave}>
             {this.renderResults()}


### PR DESCRIPTION
### Summary

This feature adds the previously searched query to the search bar on a page

### Test Plan

Went to start page. Placeholder text was still present. No default text seen. Searched for something. Verified that the correct query showed up.

