### PR TITLE
Remove jquery from deprecated code

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -10,7 +10,6 @@
     "axios": "^0.19.2",
     "chart.js": "^2.9.3",
     "common": "0.0.1",
-    "jquery": "^2.2.4",
     "react": "^16.13.1",
     "react-chartkick": "^0.4.0",
     "react-circular-progressbar": "^2.0.3",
@@ -48,7 +47,6 @@
     ]
   },
   "devDependencies": {
-    "@types/jquery": "^3.3.34",
     "@types/react-router-dom": "^5.1.3"
   }
 }

--- a/client/src/index.tsx
+++ b/client/src/index.tsx
@@ -1,4 +1,3 @@
-import "./jQuery";
 import "./index.css";
 
 import React from 'react';

--- a/client/src/jQuery.ts
+++ b/client/src/jQuery.ts
@@ -1,4 +1,0 @@
-import jquery from "jquery";
-
-declare global { interface Window { $: typeof jquery } }
-window.$ = jquery;

--- a/client/src/ui/Form.jsx
+++ b/client/src/ui/Form.jsx
@@ -1,4 +1,3 @@
-/* globals $ */
 import React, { Component} from 'react';
 import PropTypes from 'prop-types';
 
@@ -36,7 +35,6 @@ export default class Form extends Component {
 
     //Define refs
 
-    this.dropdownMenu=React.createRef();
     this.noProfMsg=React.createRef();
     this.profSelect=React.createRef();
     this.emptyMsg=React.createRef();
@@ -46,10 +44,7 @@ export default class Form extends Component {
 
     //store all currently selected form values in the state.
 
-    this.openByDefault = true;
-
     this.state = {
-      dropdown: '', //empty as opposed to 'open'
       visible: false,
       "rating": 3,
       "ratinglastSelect": 3,
@@ -75,7 +70,6 @@ export default class Form extends Component {
     // store inital values as the default state to revert to after submission
     this.defaultState = this.state
     this.handleProfChange.bind(this)
-    this.toggleDropdown.bind(this)
     this.submitReview = this.submitReview.bind(this)
     this.submitError = this.submitError.bind(this)
     this.saveReviewToSession = this.saveReviewToSession.bind(this)
@@ -116,7 +110,6 @@ export default class Form extends Component {
     }
     
     this.setState({ selectedProfessors: selectedProfessors });
-    this.pushReviewsDown(this.state.dropdown);
   }
 
   //Called when mouse  enters a metric box to chane highlighting
@@ -253,9 +246,6 @@ export default class Form extends Component {
         // Success, so reset form
 
         this.profSelect.current.value = "none";
-        if(this.openByDefault){
-          this.toggleDropdown(); //Open review dropdown when page loads
-        }
 
         // Reset review info to default after review submission
         this.setState(this.defaultState);
@@ -325,34 +315,6 @@ export default class Form extends Component {
     }
   }
 
-
-    // Toggle the form dropdown
-    // Takes care of "pushing down" the reviews by the dynamic height of the form
-    toggleDropdown(){
-       const nextState = this.state.dropdown === 'open' ? '' : 'open';
-       this.setState({ dropdown: nextState });
-       this.pushReviewsDown(nextState);
-    }
-
-    //Pushes down the reviews from the form depending on how long the form becomes
-    //Uses the margin-bottom attribute to do this
-    pushReviewsDown(formState){
-      let marginHeight;
-      let offsetHeight;
-      // Form is opened
-      if (formState === 'open'){
-        marginHeight = this.dropdownHeight;
-        offsetHeight = this.selectHolder.current.offsetHeight - 46;
-      }
-      // Form is closed
-      else{
-        marginHeight = 0;
-        offsetHeight = 0;
-      }
-      if(offsetHeight >= 0){
-        $("#form-dropdown").css("margin-bottom", (marginHeight + offsetHeight) + "px");
-      }
-    }
     show() {
         this.setState({ visible: true });
     }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1611,13 +1611,6 @@
     jest-diff "^25.2.1"
     pretty-format "^25.2.1"
 
-"@types/jquery@^3.3.34":
-  version "3.3.38"
-  resolved "https://registry.yarnpkg.com/@types/jquery/-/jquery-3.3.38.tgz#6385f1e1b30bd2bff55ae8ee75ea42a999cc3608"
-  integrity sha512-nkDvmx7x/6kDM5guu/YpXkGZ/Xj/IwGiLDdKM99YA5Vag7pjGyTJ8BNUh/6hxEn/sEu5DKtyRgnONJ7EmOoKrA==
-  dependencies:
-    "@types/sizzle" "*"
-
 "@types/json-schema@^7.0.3":
   version "7.0.4"
   resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.4.tgz#38fd73ddfd9b55abb1e1b2ed578cb55bd7b7d339"
@@ -1745,11 +1738,6 @@
   version "0.0.29"
   resolved "https://registry.yarnpkg.com/@types/shortid/-/shortid-0.0.29.tgz#8093ee0416a6e2bf2aa6338109114b3fbffa0e9b"
   integrity sha1-gJPuBBam4r8qpjOBCRFLP7/6Dps=
-
-"@types/sizzle@*":
-  version "2.3.2"
-  resolved "https://registry.yarnpkg.com/@types/sizzle/-/sizzle-2.3.2.tgz#a811b8c18e2babab7d542b3365887ae2e4d9de47"
-  integrity sha512-7EJYyKTL7tFR8+gDbB6Wwz/arpGa0Mywk1TJbNzKzHtzbwVmY4HR9WqS5VV7dsBUKQmPNr192jHr/VpBluj/hg==
 
 "@types/stack-utils@^1.0.1":
   version "1.0.1"
@@ -6696,11 +6684,6 @@ jest@24.9.0:
   dependencies:
     import-local "^2.0.0"
     jest-cli "^24.9.0"
-
-jquery@^2.2.4:
-  version "2.2.4"
-  resolved "https://registry.yarnpkg.com/jquery/-/jquery-2.2.4.tgz#2c89d6889b5eac522a7eea32c14521559c6cbf02"
-  integrity sha1-LInWiJterFIqfuoywUUhVZxsvwI=
 
 "js-tokens@^3.0.0 || ^4.0.0", js-tokens@^4.0.0:
   version "4.0.0"


### PR DESCRIPTION
### Summary <!-- Required -->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Itemize bug fixes, new features, and other changes -->
<!-- Feel free to break this into sub-sections, i.e. features, fixes, etc. -->
<!-- Some examples are shown below. -->

This PR removes jQuery as a dependency in `/client/index.ts` and therefore completely from the codebase

It was being used for a deprecated feature in a function that was no longer relevant - I've removed that function as well.

### Test Plan <!-- Required -->

<!-- Provide screenshots or point out the additional unit tests -->

Tested typical workflow locally
