### PR TITLE
Improved Scraper 2

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,661 @@
+                    GNU AFFERO GENERAL PUBLIC LICENSE
+                       Version 3, 19 November 2007
+
+ Copyright (C) 2007 Free Software Foundation, Inc. <https://fsf.org/>
+ Everyone is permitted to copy and distribute verbatim copies
+ of this license document, but changing it is not allowed.
+
+                            Preamble
+
+  The GNU Affero General Public License is a free, copyleft license for
+software and other kinds of works, specifically designed to ensure
+cooperation with the community in the case of network server software.
+
+  The licenses for most software and other practical works are designed
+to take away your freedom to share and change the works.  By contrast,
+our General Public Licenses are intended to guarantee your freedom to
+share and change all versions of a program--to make sure it remains free
+software for all its users.
+
+  When we speak of free software, we are referring to freedom, not
+price.  Our General Public Licenses are designed to make sure that you
+have the freedom to distribute copies of free software (and charge for
+them if you wish), that you receive source code or can get it if you
+want it, that you can change the software or use pieces of it in new
+free programs, and that you know you can do these things.
+
+  Developers that use our General Public Licenses protect your rights
+with two steps: (1) assert copyright on the software, and (2) offer
+you this License which gives you legal permission to copy, distribute
+and/or modify the software.
+
+  A secondary benefit of defending all users' freedom is that
+improvements made in alternate versions of the program, if they
+receive widespread use, become available for other developers to
+incorporate.  Many developers of free software are heartened and
+encouraged by the resulting cooperation.  However, in the case of
+software used on network servers, this result may fail to come about.
+The GNU General Public License permits making a modified version and
+letting the public access it on a server without ever releasing its
+source code to the public.
+
+  The GNU Affero General Public License is designed specifically to
+ensure that, in such cases, the modified source code becomes available
+to the community.  It requires the operator of a network server to
+provide the source code of the modified version running there to the
+users of that server.  Therefore, public use of a modified version, on
+a publicly accessible server, gives the public access to the source
+code of the modified version.
+
+  An older license, called the Affero General Public License and
+published by Affero, was designed to accomplish similar goals.  This is
+a different license, not a version of the Affero GPL, but Affero has
+released a new version of the Affero GPL which permits relicensing under
+this license.
+
+  The precise terms and conditions for copying, distribution and
+modification follow.
+
+                       TERMS AND CONDITIONS
+
+  0. Definitions.
+
+  "This License" refers to version 3 of the GNU Affero General Public License.
+
+  "Copyright" also means copyright-like laws that apply to other kinds of
+works, such as semiconductor masks.
+
+  "The Program" refers to any copyrightable work licensed under this
+License.  Each licensee is addressed as "you".  "Licensees" and
+"recipients" may be individuals or organizations.
+
+  To "modify" a work means to copy from or adapt all or part of the work
+in a fashion requiring copyright permission, other than the making of an
+exact copy.  The resulting work is called a "modified version" of the
+earlier work or a work "based on" the earlier work.
+
+  A "covered work" means either the unmodified Program or a work based
+on the Program.
+
+  To "propagate" a work means to do anything with it that, without
+permission, would make you directly or secondarily liable for
+infringement under applicable copyright law, except executing it on a
+computer or modifying a private copy.  Propagation includes copying,
+distribution (with or without modification), making available to the
+public, and in some countries other activities as well.
+
+  To "convey" a work means any kind of propagation that enables other
+parties to make or receive copies.  Mere interaction with a user through
+a computer network, with no transfer of a copy, is not conveying.
+
+  An interactive user interface displays "Appropriate Legal Notices"
+to the extent that it includes a convenient and prominently visible
+feature that (1) displays an appropriate copyright notice, and (2)
+tells the user that there is no warranty for the work (except to the
+extent that warranties are provided), that licensees may convey the
+work under this License, and how to view a copy of this License.  If
+the interface presents a list of user commands or options, such as a
+menu, a prominent item in the list meets this criterion.
+
+  1. Source Code.
+
+  The "source code" for a work means the preferred form of the work
+for making modifications to it.  "Object code" means any non-source
+form of a work.
+
+  A "Standard Interface" means an interface that either is an official
+standard defined by a recognized standards body, or, in the case of
+interfaces specified for a particular programming language, one that
+is widely used among developers working in that language.
+
+  The "System Libraries" of an executable work include anything, other
+than the work as a whole, that (a) is included in the normal form of
+packaging a Major Component, but which is not part of that Major
+Component, and (b) serves only to enable use of the work with that
+Major Component, or to implement a Standard Interface for which an
+implementation is available to the public in source code form.  A
+"Major Component", in this context, means a major essential component
+(kernel, window system, and so on) of the specific operating system
+(if any) on which the executable work runs, or a compiler used to
+produce the work, or an object code interpreter used to run it.
+
+  The "Corresponding Source" for a work in object code form means all
+the source code needed to generate, install, and (for an executable
+work) run the object code and to modify the work, including scripts to
+control those activities.  However, it does not include the work's
+System Libraries, or general-purpose tools or generally available free
+programs which are used unmodified in performing those activities but
+which are not part of the work.  For example, Corresponding Source
+includes interface definition files associated with source files for
+the work, and the source code for shared libraries and dynamically
+linked subprograms that the work is specifically designed to require,
+such as by intimate data communication or control flow between those
+subprograms and other parts of the work.
+
+  The Corresponding Source need not include anything that users
+can regenerate automatically from other parts of the Corresponding
+Source.
+
+  The Corresponding Source for a work in source code form is that
+same work.
+
+  2. Basic Permissions.
+
+  All rights granted under this License are granted for the term of
+copyright on the Program, and are irrevocable provided the stated
+conditions are met.  This License explicitly affirms your unlimited
+permission to run the unmodified Program.  The output from running a
+covered work is covered by this License only if the output, given its
+content, constitutes a covered work.  This License acknowledges your
+rights of fair use or other equivalent, as provided by copyright law.
+
+  You may make, run and propagate covered works that you do not
+convey, without conditions so long as your license otherwise remains
+in force.  You may convey covered works to others for the sole purpose
+of having them make modifications exclusively for you, or provide you
+with facilities for running those works, provided that you comply with
+the terms of this License in conveying all material for which you do
+not control copyright.  Those thus making or running the covered works
+for you must do so exclusively on your behalf, under your direction
+and control, on terms that prohibit them from making any copies of
+your copyrighted material outside their relationship with you.
+
+  Conveying under any other circumstances is permitted solely under
+the conditions stated below.  Sublicensing is not allowed; section 10
+makes it unnecessary.
+
+  3. Protecting Users' Legal Rights From Anti-Circumvention Law.
+
+  No covered work shall be deemed part of an effective technological
+measure under any applicable law fulfilling obligations under article
+11 of the WIPO copyright treaty adopted on 20 December 1996, or
+similar laws prohibiting or restricting circumvention of such
+measures.
+
+  When you convey a covered work, you waive any legal power to forbid
+circumvention of technological measures to the extent such circumvention
+is effected by exercising rights under this License with respect to
+the covered work, and you disclaim any intention to limit operation or
+modification of the work as a means of enforcing, against the work's
+users, your or third parties' legal rights to forbid circumvention of
+technological measures.
+
+  4. Conveying Verbatim Copies.
+
+  You may convey verbatim copies of the Program's source code as you
+receive it, in any medium, provided that you conspicuously and
+appropriately publish on each copy an appropriate copyright notice;
+keep intact all notices stating that this License and any
+non-permissive terms added in accord with section 7 apply to the code;
+keep intact all notices of the absence of any warranty; and give all
+recipients a copy of this License along with the Program.
+
+  You may charge any price or no price for each copy that you convey,
+and you may offer support or warranty protection for a fee.
+
+  5. Conveying Modified Source Versions.
+
+  You may convey a work based on the Program, or the modifications to
+produce it from the Program, in the form of source code under the
+terms of section 4, provided that you also meet all of these conditions:
+
+    a) The work must carry prominent notices stating that you modified
+    it, and giving a relevant date.
+
+    b) The work must carry prominent notices stating that it is
+    released under this License and any conditions added under section
+    7.  This requirement modifies the requirement in section 4 to
+    "keep intact all notices".
+
+    c) You must license the entire work, as a whole, under this
+    License to anyone who comes into possession of a copy.  This
+    License will therefore apply, along with any applicable section 7
+    additional terms, to the whole of the work, and all its parts,
+    regardless of how they are packaged.  This License gives no
+    permission to license the work in any other way, but it does not
+    invalidate such permission if you have separately received it.
+
+    d) If the work has interactive user interfaces, each must display
+    Appropriate Legal Notices; however, if the Program has interactive
+    interfaces that do not display Appropriate Legal Notices, your
+    work need not make them do so.
+
+  A compilation of a covered work with other separate and independent
+works, which are not by their nature extensions of the covered work,
+and which are not combined with it such as to form a larger program,
+in or on a volume of a storage or distribution medium, is called an
+"aggregate" if the compilation and its resulting copyright are not
+used to limit the access or legal rights of the compilation's users
+beyond what the individual works permit.  Inclusion of a covered work
+in an aggregate does not cause this License to apply to the other
+parts of the aggregate.
+
+  6. Conveying Non-Source Forms.
+
+  You may convey a covered work in object code form under the terms
+of sections 4 and 5, provided that you also convey the
+machine-readable Corresponding Source under the terms of this License,
+in one of these ways:
+
+    a) Convey the object code in, or embodied in, a physical product
+    (including a physical distribution medium), accompanied by the
+    Corresponding Source fixed on a durable physical medium
+    customarily used for software interchange.
+
+    b) Convey the object code in, or embodied in, a physical product
+    (including a physical distribution medium), accompanied by a
+    written offer, valid for at least three years and valid for as
+    long as you offer spare parts or customer support for that product
+    model, to give anyone who possesses the object code either (1) a
+    copy of the Corresponding Source for all the software in the
+    product that is covered by this License, on a durable physical
+    medium customarily used for software interchange, for a price no
+    more than your reasonable cost of physically performing this
+    conveying of source, or (2) access to copy the
+    Corresponding Source from a network server at no charge.
+
+    c) Convey individual copies of the object code with a copy of the
+    written offer to provide the Corresponding Source.  This
+    alternative is allowed only occasionally and noncommercially, and
+    only if you received the object code with such an offer, in accord
+    with subsection 6b.
+
+    d) Convey the object code by offering access from a designated
+    place (gratis or for a charge), and offer equivalent access to the
+    Corresponding Source in the same way through the same place at no
+    further charge.  You need not require recipients to copy the
+    Corresponding Source along with the object code.  If the place to
+    copy the object code is a network server, the Corresponding Source
+    may be on a different server (operated by you or a third party)
+    that supports equivalent copying facilities, provided you maintain
+    clear directions next to the object code saying where to find the
+    Corresponding Source.  Regardless of what server hosts the
+    Corresponding Source, you remain obligated to ensure that it is
+    available for as long as needed to satisfy these requirements.
+
+    e) Convey the object code using peer-to-peer transmission, provided
+    you inform other peers where the object code and Corresponding
+    Source of the work are being offered to the general public at no
+    charge under subsection 6d.
+
+  A separable portion of the object code, whose source code is excluded
+from the Corresponding Source as a System Library, need not be
+included in conveying the object code work.
+
+  A "User Product" is either (1) a "consumer product", which means any
+tangible personal property which is normally used for personal, family,
+or household purposes, or (2) anything designed or sold for incorporation
+into a dwelling.  In determining whether a product is a consumer product,
+doubtful cases shall be resolved in favor of coverage.  For a particular
+product received by a particular user, "normally used" refers to a
+typical or common use of that class of product, regardless of the status
+of the particular user or of the way in which the particular user
+actually uses, or expects or is expected to use, the product.  A product
+is a consumer product regardless of whether the product has substantial
+commercial, industrial or non-consumer uses, unless such uses represent
+the only significant mode of use of the product.
+
+  "Installation Information" for a User Product means any methods,
+procedures, authorization keys, or other information required to install
+and execute modified versions of a covered work in that User Product from
+a modified version of its Corresponding Source.  The information must
+suffice to ensure that the continued functioning of the modified object
+code is in no case prevented or interfered with solely because
+modification has been made.
+
+  If you convey an object code work under this section in, or with, or
+specifically for use in, a User Product, and the conveying occurs as
+part of a transaction in which the right of possession and use of the
+User Product is transferred to the recipient in perpetuity or for a
+fixed term (regardless of how the transaction is characterized), the
+Corresponding Source conveyed under this section must be accompanied
+by the Installation Information.  But this requirement does not apply
+if neither you nor any third party retains the ability to install
+modified object code on the User Product (for example, the work has
+been installed in ROM).
+
+  The requirement to provide Installation Information does not include a
+requirement to continue to provide support service, warranty, or updates
+for a work that has been modified or installed by the recipient, or for
+the User Product in which it has been modified or installed.  Access to a
+network may be denied when the modification itself materially and
+adversely affects the operation of the network or violates the rules and
+protocols for communication across the network.
+
+  Corresponding Source conveyed, and Installation Information provided,
+in accord with this section must be in a format that is publicly
+documented (and with an implementation available to the public in
+source code form), and must require no special password or key for
+unpacking, reading or copying.
+
+  7. Additional Terms.
+
+  "Additional permissions" are terms that supplement the terms of this
+License by making exceptions from one or more of its conditions.
+Additional permissions that are applicable to the entire Program shall
+be treated as though they were included in this License, to the extent
+that they are valid under applicable law.  If additional permissions
+apply only to part of the Program, that part may be used separately
+under those permissions, but the entire Program remains governed by
+this License without regard to the additional permissions.
+
+  When you convey a copy of a covered work, you may at your option
+remove any additional permissions from that copy, or from any part of
+it.  (Additional permissions may be written to require their own
+removal in certain cases when you modify the work.)  You may place
+additional permissions on material, added by you to a covered work,
+for which you have or can give appropriate copyright permission.
+
+  Notwithstanding any other provision of this License, for material you
+add to a covered work, you may (if authorized by the copyright holders of
+that material) supplement the terms of this License with terms:
+
+    a) Disclaiming warranty or limiting liability differently from the
+    terms of sections 15 and 16 of this License; or
+
+    b) Requiring preservation of specified reasonable legal notices or
+    author attributions in that material or in the Appropriate Legal
+    Notices displayed by works containing it; or
+
+    c) Prohibiting misrepresentation of the origin of that material, or
+    requiring that modified versions of such material be marked in
+    reasonable ways as different from the original version; or
+
+    d) Limiting the use for publicity purposes of names of licensors or
+    authors of the material; or
+
+    e) Declining to grant rights under trademark law for use of some
+    trade names, trademarks, or service marks; or
+
+    f) Requiring indemnification of licensors and authors of that
+    material by anyone who conveys the material (or modified versions of
+    it) with contractual assumptions of liability to the recipient, for
+    any liability that these contractual assumptions directly impose on
+    those licensors and authors.
+
+  All other non-permissive additional terms are considered "further
+restrictions" within the meaning of section 10.  If the Program as you
+received it, or any part of it, contains a notice stating that it is
+governed by this License along with a term that is a further
+restriction, you may remove that term.  If a license document contains
+a further restriction but permits relicensing or conveying under this
+License, you may add to a covered work material governed by the terms
+of that license document, provided that the further restriction does
+not survive such relicensing or conveying.
+
+  If you add terms to a covered work in accord with this section, you
+must place, in the relevant source files, a statement of the
+additional terms that apply to those files, or a notice indicating
+where to find the applicable terms.
+
+  Additional terms, permissive or non-permissive, may be stated in the
+form of a separately written license, or stated as exceptions;
+the above requirements apply either way.
+
+  8. Termination.
+
+  You may not propagate or modify a covered work except as expressly
+provided under this License.  Any attempt otherwise to propagate or
+modify it is void, and will automatically terminate your rights under
+this License (including any patent licenses granted under the third
+paragraph of section 11).
+
+  However, if you cease all violation of this License, then your
+license from a particular copyright holder is reinstated (a)
+provisionally, unless and until the copyright holder explicitly and
+finally terminates your license, and (b) permanently, if the copyright
+holder fails to notify you of the violation by some reasonable means
+prior to 60 days after the cessation.
+
+  Moreover, your license from a particular copyright holder is
+reinstated permanently if the copyright holder notifies you of the
+violation by some reasonable means, this is the first time you have
+received notice of violation of this License (for any work) from that
+copyright holder, and you cure the violation prior to 30 days after
+your receipt of the notice.
+
+  Termination of your rights under this section does not terminate the
+licenses of parties who have received copies or rights from you under
+this License.  If your rights have been terminated and not permanently
+reinstated, you do not qualify to receive new licenses for the same
+material under section 10.
+
+  9. Acceptance Not Required for Having Copies.
+
+  You are not required to accept this License in order to receive or
+run a copy of the Program.  Ancillary propagation of a covered work
+occurring solely as a consequence of using peer-to-peer transmission
+to receive a copy likewise does not require acceptance.  However,
+nothing other than this License grants you permission to propagate or
+modify any covered work.  These actions infringe copyright if you do
+not accept this License.  Therefore, by modifying or propagating a
+covered work, you indicate your acceptance of this License to do so.
+
+  10. Automatic Licensing of Downstream Recipients.
+
+  Each time you convey a covered work, the recipient automatically
+receives a license from the original licensors, to run, modify and
+propagate that work, subject to this License.  You are not responsible
+for enforcing compliance by third parties with this License.
+
+  An "entity transaction" is a transaction transferring control of an
+organization, or substantially all assets of one, or subdividing an
+organization, or merging organizations.  If propagation of a covered
+work results from an entity transaction, each party to that
+transaction who receives a copy of the work also receives whatever
+licenses to the work the party's predecessor in interest had or could
+give under the previous paragraph, plus a right to possession of the
+Corresponding Source of the work from the predecessor in interest, if
+the predecessor has it or can get it with reasonable efforts.
+
+  You may not impose any further restrictions on the exercise of the
+rights granted or affirmed under this License.  For example, you may
+not impose a license fee, royalty, or other charge for exercise of
+rights granted under this License, and you may not initiate litigation
+(including a cross-claim or counterclaim in a lawsuit) alleging that
+any patent claim is infringed by making, using, selling, offering for
+sale, or importing the Program or any portion of it.
+
+  11. Patents.
+
+  A "contributor" is a copyright holder who authorizes use under this
+License of the Program or a work on which the Program is based.  The
+work thus licensed is called the contributor's "contributor version".
+
+  A contributor's "essential patent claims" are all patent claims
+owned or controlled by the contributor, whether already acquired or
+hereafter acquired, that would be infringed by some manner, permitted
+by this License, of making, using, or selling its contributor version,
+but do not include claims that would be infringed only as a
+consequence of further modification of the contributor version.  For
+purposes of this definition, "control" includes the right to grant
+patent sublicenses in a manner consistent with the requirements of
+this License.
+
+  Each contributor grants you a non-exclusive, worldwide, royalty-free
+patent license under the contributor's essential patent claims, to
+make, use, sell, offer for sale, import and otherwise run, modify and
+propagate the contents of its contributor version.
+
+  In the following three paragraphs, a "patent license" is any express
+agreement or commitment, however denominated, not to enforce a patent
+(such as an express permission to practice a patent or covenant not to
+sue for patent infringement).  To "grant" such a patent license to a
+party means to make such an agreement or commitment not to enforce a
+patent against the party.
+
+  If you convey a covered work, knowingly relying on a patent license,
+and the Corresponding Source of the work is not available for anyone
+to copy, free of charge and under the terms of this License, through a
+publicly available network server or other readily accessible means,
+then you must either (1) cause the Corresponding Source to be so
+available, or (2) arrange to deprive yourself of the benefit of the
+patent license for this particular work, or (3) arrange, in a manner
+consistent with the requirements of this License, to extend the patent
+license to downstream recipients.  "Knowingly relying" means you have
+actual knowledge that, but for the patent license, your conveying the
+covered work in a country, or your recipient's use of the covered work
+in a country, would infringe one or more identifiable patents in that
+country that you have reason to believe are valid.
+
+  If, pursuant to or in connection with a single transaction or
+arrangement, you convey, or propagate by procuring conveyance of, a
+covered work, and grant a patent license to some of the parties
+receiving the covered work authorizing them to use, propagate, modify
+or convey a specific copy of the covered work, then the patent license
+you grant is automatically extended to all recipients of the covered
+work and works based on it.
+
+  A patent license is "discriminatory" if it does not include within
+the scope of its coverage, prohibits the exercise of, or is
+conditioned on the non-exercise of one or more of the rights that are
+specifically granted under this License.  You may not convey a covered
+work if you are a party to an arrangement with a third party that is
+in the business of distributing software, under which you make payment
+to the third party based on the extent of your activity of conveying
+the work, and under which the third party grants, to any of the
+parties who would receive the covered work from you, a discriminatory
+patent license (a) in connection with copies of the covered work
+conveyed by you (or copies made from those copies), or (b) primarily
+for and in connection with specific products or compilations that
+contain the covered work, unless you entered into that arrangement,
+or that patent license was granted, prior to 28 March 2007.
+
+  Nothing in this License shall be construed as excluding or limiting
+any implied license or other defenses to infringement that may
+otherwise be available to you under applicable patent law.
+
+  12. No Surrender of Others' Freedom.
+
+  If conditions are imposed on you (whether by court order, agreement or
+otherwise) that contradict the conditions of this License, they do not
+excuse you from the conditions of this License.  If you cannot convey a
+covered work so as to satisfy simultaneously your obligations under this
+License and any other pertinent obligations, then as a consequence you may
+not convey it at all.  For example, if you agree to terms that obligate you
+to collect a royalty for further conveying from those to whom you convey
+the Program, the only way you could satisfy both those terms and this
+License would be to refrain entirely from conveying the Program.
+
+  13. Remote Network Interaction; Use with the GNU General Public License.
+
+  Notwithstanding any other provision of this License, if you modify the
+Program, your modified version must prominently offer all users
+interacting with it remotely through a computer network (if your version
+supports such interaction) an opportunity to receive the Corresponding
+Source of your version by providing access to the Corresponding Source
+from a network server at no charge, through some standard or customary
+means of facilitating copying of software.  This Corresponding Source
+shall include the Corresponding Source for any work covered by version 3
+of the GNU General Public License that is incorporated pursuant to the
+following paragraph.
+
+  Notwithstanding any other provision of this License, you have
+permission to link or combine any covered work with a work licensed
+under version 3 of the GNU General Public License into a single
+combined work, and to convey the resulting work.  The terms of this
+License will continue to apply to the part which is the covered work,
+but the work with which it is combined will remain governed by version
+3 of the GNU General Public License.
+
+  14. Revised Versions of this License.
+
+  The Free Software Foundation may publish revised and/or new versions of
+the GNU Affero General Public License from time to time.  Such new versions
+will be similar in spirit to the present version, but may differ in detail to
+address new problems or concerns.
+
+  Each version is given a distinguishing version number.  If the
+Program specifies that a certain numbered version of the GNU Affero General
+Public License "or any later version" applies to it, you have the
+option of following the terms and conditions either of that numbered
+version or of any later version published by the Free Software
+Foundation.  If the Program does not specify a version number of the
+GNU Affero General Public License, you may choose any version ever published
+by the Free Software Foundation.
+
+  If the Program specifies that a proxy can decide which future
+versions of the GNU Affero General Public License can be used, that proxy's
+public statement of acceptance of a version permanently authorizes you
+to choose that version for the Program.
+
+  Later license versions may give you additional or different
+permissions.  However, no additional obligations are imposed on any
+author or copyright holder as a result of your choosing to follow a
+later version.
+
+  15. Disclaimer of Warranty.
+
+  THERE IS NO WARRANTY FOR THE PROGRAM, TO THE EXTENT PERMITTED BY
+APPLICABLE LAW.  EXCEPT WHEN OTHERWISE STATED IN WRITING THE COPYRIGHT
+HOLDERS AND/OR OTHER PARTIES PROVIDE THE PROGRAM "AS IS" WITHOUT WARRANTY
+OF ANY KIND, EITHER EXPRESSED OR IMPLIED, INCLUDING, BUT NOT LIMITED TO,
+THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+PURPOSE.  THE ENTIRE RISK AS TO THE QUALITY AND PERFORMANCE OF THE PROGRAM
+IS WITH YOU.  SHOULD THE PROGRAM PROVE DEFECTIVE, YOU ASSUME THE COST OF
+ALL NECESSARY SERVICING, REPAIR OR CORRECTION.
+
+  16. Limitation of Liability.
+
+  IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING
+WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MODIFIES AND/OR CONVEYS
+THE PROGRAM AS PERMITTED ABOVE, BE LIABLE TO YOU FOR DAMAGES, INCLUDING ANY
+GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES ARISING OUT OF THE
+USE OR INABILITY TO USE THE PROGRAM (INCLUDING BUT NOT LIMITED TO LOSS OF
+DATA OR DATA BEING RENDERED INACCURATE OR LOSSES SUSTAINED BY YOU OR THIRD
+PARTIES OR A FAILURE OF THE PROGRAM TO OPERATE WITH ANY OTHER PROGRAMS),
+EVEN IF SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE POSSIBILITY OF
+SUCH DAMAGES.
+
+  17. Interpretation of Sections 15 and 16.
+
+  If the disclaimer of warranty and limitation of liability provided
+above cannot be given local legal effect according to their terms,
+reviewing courts shall apply local law that most closely approximates
+an absolute waiver of all civil liability in connection with the
+Program, unless a warranty or assumption of liability accompanies a
+copy of the Program in return for a fee.
+
+                     END OF TERMS AND CONDITIONS
+
+            How to Apply These Terms to Your New Programs
+
+  If you develop a new program, and you want it to be of the greatest
+possible use to the public, the best way to achieve this is to make it
+free software which everyone can redistribute and change under these terms.
+
+  To do so, attach the following notices to the program.  It is safest
+to attach them to the start of each source file to most effectively
+state the exclusion of warranty; and each file should have at least
+the "copyright" line and a pointer to where the full notice is found.
+
+    <one line to give the program's name and a brief idea of what it does.>
+    Copyright (C) <year>  <name of author>
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Affero General Public License as published
+    by the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Affero General Public License for more details.
+
+    You should have received a copy of the GNU Affero General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+Also add information on how to contact you by electronic and paper mail.
+
+  If your software can interact with users remotely through a computer
+network, you should also make sure that it provides a way for users to
+get its source.  For example, if your program is a web application, its
+interface could display a "Source" link that leads users to an archive
+of the code.  There are many ways you could offer source, and different
+solutions will be better for different programs; see section 13 for the
+specific requirements.
+
+  You should also get your employer (if you work as a programmer) or school,
+if any, to sign a "copyright disclaimer" for the program, if necessary.
+For more information on this, and how to apply and follow the GNU AGPL, see
+<https://www.gnu.org/licenses/>.

--- a/README.md
+++ b/README.md
@@ -35,14 +35,13 @@ Option 1:
 Previously, you would start a server like so:
 
 ```bash
-# directly
 MONGODB_URL='mongodb://foo' yarn workspace server start 
 ```
 
 There is also something called "fallback mode", which you can trigger by starting the server with the ALLOW_LOCAL env variable set to 1, and **without** setting MONGODB_URL. Fallback mode automatically configures a blank mongodb for use in the application, and then scrapes some data from Cornell's endpoint for you to test. There will not be any reviews by default.
 
 ```bash
-ALLOW_LOCAL=1 yarn workspace server start # or using .env file
+ALLOW_LOCAL=1 yarn workspace server start
 ```
 
 Option 2:

--- a/README.md
+++ b/README.md
@@ -27,8 +27,27 @@ MONGODB_URL=[SECRET_URL_ASK_TEAM_MEMBER_FOR_IT]
 
 **You will probably use the address of the staging server.** If, for some reason you want to have a local db (E.g. you're making some changes to the db structure, and don't want to accidently trash the staging db), the following works:
 
-<details><summary>Running a local mongodb server</summary>
+<details><summary>Running using local mongodb server</summary>
 <p>
+
+Option 1:
+
+Previously, you would start a server like so:
+
+```bash
+# directly
+MONGODB_URL='mongodb://foo' yarn workspace server start 
+```
+
+There is also something called "fallback mode", which you can trigger by starting the server with the ALLOW_LOCAL env variable set to 1, and **without** setting MONGODB_URL. Fallback mode automatically configures a blank mongodb for use in the application, and then scrapes some data from Cornell's endpoint for you to test. There will not be any reviews by default.
+
+```bash
+ALLOW_LOCAL=1 yarn workspace server start # or using .env file
+```
+
+Option 2:
+
+<details><summary>If you really, really do want to use a local Mongo instance using mongod (not recommended), this might work: </summary>
 
 You need the mongodb database tools and server installed. They are available [here](https://docs.mongodb.com/database-tools/) and [here](https://www.mongodb.com/download-center/community). If, for some reason, you want to use the tools on a linux box, you will probably have to build them from source [here](https://github.com/mongodb/mongo-tools).
 
@@ -46,6 +65,7 @@ mongorestore -h 127.0.0.1 --port 3001 -d test /path/to/your/bson.bson --drop
 ```
 
 You will probably need to run this for the `classes`, `subjects` and `reviews` collections (Perhaps also `students`). Ask a team member for the bsons if you need them. If this errors, it might be because the `-d test` specifies the wrong database name (`test`), in which case you should figure out your db name, and replace `-d test` with `-d dbname`. Note that it **won't** error on the command, the only evidence of an error is that none of collections will be show up on the site (i.e. no classes visible).
+</details>
 
 </p>
 </details>

--- a/server/dbInit.test.ts
+++ b/server/dbInit.test.ts
@@ -13,7 +13,10 @@ jasmine.DEFAULT_TIMEOUT_INTERVAL = 600000;
 let testServer: MongoMemoryServer;
 let serverCloseHandle;
 
-// Configure a mongo server and fake enpoints for the tests to use
+const testingPort = 27760;
+const testingEndpoint = `http://localhost:${testingPort}/`;
+
+// Configure a mongo server and fake endpoints for the tests to use
 beforeAll(async () => {
   // get mongoose all set up
   testServer = new MongoMemoryServer();
@@ -39,11 +42,9 @@ beforeAll(async () => {
     classDifficulty: 5,
   }).save().catch((err) => { console.log(err); });
 
-  console.log(await Subjects.findOne({ subShort: "GORK" }));
-
   // We need to pretend to have access to a cornell classes endpoint
   const app = express();
-  serverCloseHandle = app.listen(27760, async () => {});
+  serverCloseHandle = app.listen(testingPort, async () => {});
 
   app.get("/hello", (req, res) => {
     res.send("Hello world");
@@ -99,8 +100,6 @@ afterAll(async () => {
   serverCloseHandle.close();
 });
 
-const testingEndpoint = "http://localhost:27760/";
-
 describe('tests', () => {
   it("dbInit-db-works", async () => {
     expect((await Subjects.findOne({ subShort: "GORK" })).subShort).toBe("GORK");
@@ -108,7 +107,7 @@ describe('tests', () => {
   });
 
   // Does the internal testing endpoint exist?
-  it("dbInit-test-enpoint-exists", async () => {
+  it("dbInit-test-endpoint-exists", async () => {
     const response = await axios.get(`${testingEndpoint}hello`);
     expect(response.data).toBe("Hello world");
     expect(response.data).not.toBe("Something the enpoint is not to return!");

--- a/server/dbInit.test.ts
+++ b/server/dbInit.test.ts
@@ -25,16 +25,16 @@ beforeAll(async () => {
 
   await new Subjects({
     _id: "some id",
-    subShort: "GORK",
+    subShort: "gork",
     subFull: "Study of Angry Fungi",
   }).save();
 
   await new Classes({
     _id: "some other id",
-    classSub: "GORK",
+    classSub: "gork",
     classNum: "1110",
     classTitle: "Introduction to Angry Fungi",
-    classFull: "GORK 1110 Introduction to Angry Fungi",
+    classFull: "gork 1110 Introduction to Angry Fungi",
     classSems: ["FA19"],
     classProfessors: ["Prof. Thraka"],
     classRating: 5,
@@ -65,8 +65,8 @@ beforeAll(async () => {
       status: "success",
       data: {
         subjects: [
-          { descr: "Study of Fungi", descrformal: "The Study of Fungi", value: "GORK" },
-          { descr: "Study of Space", descrformal: "The Study of Where No One has Gone Before", value: "FEDN" },
+          { descr: "Study of Fungi", descrformal: "The Study of Fungi", value: "gork" },
+          { descr: "Study of Space", descrformal: "The Study of Where No One has Gone Before", value: "fedn" },
         ],
       },
     });
@@ -74,9 +74,9 @@ beforeAll(async () => {
 
   // Fake classes endpoint
   app.get("/search/classes.json", (req, res) => {
-    // simulate only having data for the GORK subject.
+    // simulate only having data for the gork subject.
     // see above
-    if (!req.originalUrl.includes("GORK")) {
+    if (!req.originalUrl.includes("gork")) {
       res.send({
         status: "failure",
       });
@@ -86,8 +86,14 @@ beforeAll(async () => {
       status: "success",
       data: {
         classes: [
-          { subject: "GORK", catalogNbr: "1110", titleLong: "Introduction to Angry Fungi", randoJunk: "Making sure this scauses no issues" },
-          { junk: "nada", subject: "GORK", catalogNbr: "2110", titleLong: "Advanced Study of Angry Fungi" },
+          { 
+            subject: "gork", catalogNbr: "1110", titleLong: "Introduction to Angry Fungi", randoJunk: "Making sure this scauses no issues",
+            enrollGroups: [] // TODO add tests for professors
+          },
+          { 
+            junk: "nada", subject: "gork", catalogNbr: "2110", titleLong: "Advanced Study of Angry Fungi",
+            enrollGroups: []
+          },
         ],
       },
     });
@@ -102,8 +108,8 @@ afterAll(async () => {
 
 describe('tests', () => {
   it("dbInit-db-works", async () => {
-    expect((await Subjects.findOne({ subShort: "GORK" })).subShort).toBe("GORK");
-    expect((await Classes.findOne({ classSub: "GORK", classNum: "1110" })).classSub).toBe("GORK");
+    expect((await Subjects.findOne({ subShort: "gork" })).subShort).toBe("gork");
+    expect((await Classes.findOne({ classSub: "gork", classNum: "1110" })).classSub).toBe("gork");
   });
 
   // Does the internal testing endpoint exist?
@@ -118,8 +124,8 @@ describe('tests', () => {
     const response = await fetchSubjects(testingEndpoint, "FA20");
     expect(response.length).toBe(2);
     expect(response[0].descrformal).toBe("The Study of Fungi");
-    expect(response[0].value).toBe("GORK");
-    expect(response[1].value).toBe("FEDN");
+    expect(response[0].value).toBe("gork");
+    expect(response[1].value).toBe("fedn");
 
     // No data for FA19!
     const nil = await fetchSubjects(testingEndpoint, "FA19");
@@ -128,15 +134,15 @@ describe('tests', () => {
 
   // Does fetching the classes collection work as expected?
   it("fetching-classes-by-subject-works", async () => {
-    const response = await fetchClassesForSubject(testingEndpoint, "FA20", { descrformal: "The Study of AngryFungi", value: "GORK" });
+    const response = await fetchClassesForSubject(testingEndpoint, "FA20", { descrformal: "The Study of AngryFungi", value: "gork" });
     expect(response.length).toBe(2);
-    expect(response[0].subject).toBe("GORK");
+    expect(response[0].subject).toBe("gork");
     expect(response[0].catalogNbr).toBe("1110");
     expect(response[0].titleLong).toBe("Introduction to Angry Fungi");
     expect(response[1].titleLong).toBe("Advanced Study of Angry Fungi");
 
-    // No FEDN classes, only GORK classes!
-    const nil = await fetchClassesForSubject(testingEndpoint, "FA20", { descrformal: "The Study of Where No One has Gone Before", value: "FEDN" });
+    // No fedn classes, only gork classes!
+    const nil = await fetchClassesForSubject(testingEndpoint, "FA20", { descrformal: "The Study of Where No One has Gone Before", value: "fedn" });
     expect(nil).toBeNull();
   });
 
@@ -144,14 +150,14 @@ describe('tests', () => {
     const worked = await fetchAddCourses(testingEndpoint, "FA20");
     expect(worked).toBe(true);
 
-    // did it add the FEDN subject?
-    expect((await Subjects.findOne({ subShort: "FEDN" }).exec()).subFull).toBe("The Study of Where No One has Gone Before");
+    // did it add the fedn subject?
+    expect((await Subjects.findOne({ subShort: "fedn" }).exec()).subFull).toBe("The Study of Where No One has Gone Before");
 
-    // did it update the semesters on GORK 1110?
+    // did it update the semesters on gork 1110?
     // notice the .lean(), which changes some of the internals of what mongo returns
-    expect((await Classes.findOne({ classSub: "GORK", classNum: "1110" }).lean().exec()).classSems).toStrictEqual(["FA19", "FA20"]);
+    expect((await Classes.findOne({ classSub: "gork", classNum: "1110" }).lean().exec()).classSems).toStrictEqual(["FA19", "FA20"]);
 
-    // did it add the GORK 2110 Class?
-    expect((await Classes.findOne({ classSub: "GORK", classNum: "2110" }).exec()).classTitle).toBe("Advanced Study of Angry Fungi");
+    // did it add the gork 2110 Class?
+    expect((await Classes.findOne({ classSub: "gork", classNum: "2110" }).exec()).classTitle).toBe("Advanced Study of Angry Fungi");
   });
 });

--- a/server/dbInit.test.ts
+++ b/server/dbInit.test.ts
@@ -11,6 +11,7 @@ import { fetchSubjects, fetchClassesForSubject, fetchAddCourses } from "./dbInit
 jasmine.DEFAULT_TIMEOUT_INTERVAL = 600000;
 
 let testServer: MongoMemoryServer;
+let serverCloseHandle;
 
 // Configure a mongo server and fake enpoints for the tests to use
 beforeAll(async () => {
@@ -42,7 +43,7 @@ beforeAll(async () => {
 
   // We need to pretend to have access to a cornell classes endpoint
   const app = express();
-  app.listen(27760, async () => {});
+  serverCloseHandle = app.listen(27760, async () => {});
 
   app.get("/hello", (req, res) => {
     res.send("Hello world");
@@ -95,6 +96,7 @@ beforeAll(async () => {
 afterAll(async () => {
   await mongoose.disconnect();
   await testServer.stop();
+  serverCloseHandle.close();
 });
 
 const testingEndpoint = "http://localhost:27760/";

--- a/server/dbInit.test.ts
+++ b/server/dbInit.test.ts
@@ -92,7 +92,7 @@ beforeAll(async () => {
             catalogNbr: "1110",
             titleLong: "Introduction to Angry Fungi",
             randoJunk: "Making sure this scauses no issues",
-            enrollGroups: [{ classSections: [{ ssrComponent: "LEC", meetings: [{ instructors: [{ firstName: "Prof.", lastName: "Thraka" }] }] }] }], // TODO add tests for professors
+            enrollGroups: [{ classSections: [{ ssrComponent: "LEC", meetings: [{ instructors: [{ firstName: "Prof.", lastName: "Thraka" }] }] }] }],
           },
           {
             junk: "nada",

--- a/server/dbInit.test.ts
+++ b/server/dbInit.test.ts
@@ -110,7 +110,7 @@ describe('tests', () => {
   it("dbInit-test-endpoint-exists", async () => {
     const response = await axios.get(`${testingEndpoint}hello`);
     expect(response.data).toBe("Hello world");
-    expect(response.data).not.toBe("Something the enpoint is not to return!");
+    expect(response.data).not.toBe("Something the endpoint is not to return!");
   });
 
   // Does fetching the subjects collection work as expected?

--- a/server/dbInit.test.ts
+++ b/server/dbInit.test.ts
@@ -86,13 +86,19 @@ beforeAll(async () => {
       status: "success",
       data: {
         classes: [
-          { 
-            subject: "gork", catalogNbr: "1110", titleLong: "Introduction to Angry Fungi", randoJunk: "Making sure this scauses no issues",
-            enrollGroups: [] // TODO add tests for professors
+          {
+            subject: "gork",
+            catalogNbr: "1110",
+            titleLong: "Introduction to Angry Fungi",
+            randoJunk: "Making sure this scauses no issues",
+            enrollGroups: [], // TODO add tests for professors
           },
-          { 
-            junk: "nada", subject: "gork", catalogNbr: "2110", titleLong: "Advanced Study of Angry Fungi",
-            enrollGroups: []
+          {
+            junk: "nada",
+            subject: "gork",
+            catalogNbr: "2110",
+            titleLong: "Advanced Study of Angry Fungi",
+            enrollGroups: [],
           },
         ],
       },

--- a/server/dbInit.test.ts
+++ b/server/dbInit.test.ts
@@ -1,0 +1,156 @@
+// Set up fake endpoints to query
+import express from "express";
+import axios from "axios";
+import { MongoMemoryServer } from "mongodb-memory-server";
+import mongoose from "mongoose";
+import { Subjects, Classes } from "./dbDefs";
+import { fetchSubjects, fetchClassesForSubject, fetchAddCourses } from "./dbInit";
+
+// May require additional time for downloading 100 mb (!) worth of MongoDB binaries
+// **We might not want to run this with CI**
+jasmine.DEFAULT_TIMEOUT_INTERVAL = 600000;
+
+let testServer: MongoMemoryServer;
+
+// Configure a mongo server and fake enpoints for the tests to use
+beforeAll(async () => {
+  // get mongoose all set up
+  testServer = new MongoMemoryServer();
+  const mongoUri = await testServer.getUri();
+  await mongoose.connect(mongoUri, { useNewUrlParser: true, useUnifiedTopology: true });
+
+  await new Subjects({
+    _id: "some id",
+    subShort: "GORK",
+    subFull: "Study of Angry Fungi",
+  }).save();
+
+  await new Classes({
+    _id: "some other id",
+    classSub: "GORK",
+    classNum: "1110",
+    classTitle: "Introduction to Angry Fungi",
+    classFull: "GORK 1110 Introduction to Angry Fungi",
+    classSems: ["FA19"],
+    classProfessors: ["Prof. Thraka"],
+    classRating: 5,
+    classWorkload: 5,
+    classDifficulty: 5,
+  }).save().catch((err) => { console.log(err); });
+
+  console.log(await Subjects.findOne({ subShort: "GORK" }));
+
+  // We need to pretend to have access to a cornell classes endpoint
+  const app = express();
+  app.listen(1776, async () => {});
+
+  app.get("/hello", (req, res) => {
+    res.send("Hello world");
+  });
+
+  // Fake subjects endpoint
+  app.get("/config/subjects.json", (req, res) => {
+    // simulate only having FA20 data.
+    // express did not allow me to include a "?" literal in the path for some strange reason
+    // Maybe fix in the future?
+    if (!req.originalUrl.includes("FA20")) {
+      res.send({
+        status: "failure",
+      });
+    }
+
+    res.send({
+      status: "success",
+      data: {
+        subjects: [
+          { descr: "Study of Fungi", descrformal: "The Study of Fungi", value: "GORK" },
+          { descr: "Study of Space", descrformal: "The Study of Where No One has Gone Before", value: "FEDN" },
+        ],
+      },
+    });
+  });
+
+  // Fake classes endpoint
+  app.get("/search/classes.json", (req, res) => {
+    // simulate only having data for the GORK subject.
+    // see above
+    if (!req.originalUrl.includes("GORK")) {
+      res.send({
+        status: "failure",
+      });
+    }
+
+    res.send({
+      status: "success",
+      data: {
+        classes: [
+          { subject: "GORK", catalogNbr: "1110", titleLong: "Introduction to Angry Fungi", randoJunk: "Making sure this scauses no issues" },
+          { junk: "nada", subject: "GORK", catalogNbr: "2110", titleLong: "Advanced Study of Angry Fungi" },
+        ],
+      },
+    });
+  });
+});
+
+afterAll(async () => {
+  await mongoose.disconnect();
+  await testServer.stop();
+});
+
+const testingEndpoint = "http://localhost:1776/";
+
+describe('tests', () => {
+  it("dbInit-db-works", async () => {
+    expect((await Subjects.findOne({ subShort: "GORK" })).subShort).toBe("GORK");
+    expect((await Classes.findOne({ classSub: "GORK", classNum: "1110" })).classSub).toBe("GORK");
+  });
+
+  // Does the internal testing endpoint exist?
+  it("dbInit-test-enpoint-exists", async () => {
+    const response = await axios.get(`${testingEndpoint}hello`);
+    expect(response.data).toBe("Hello world");
+    expect(response.data).not.toBe("Something the enpoint is not to return!");
+  });
+
+  // Does fetching the subjects collection work as expected?
+  it("fetching-roster-works", async () => {
+    const response = await fetchSubjects(testingEndpoint, "FA20");
+    expect(response.length).toBe(2);
+    expect(response[0].descrformal).toBe("The Study of Fungi");
+    expect(response[0].value).toBe("GORK");
+    expect(response[1].value).toBe("FEDN");
+
+    // No data for FA19!
+    const nil = await fetchSubjects(testingEndpoint, "FA19");
+    expect(nil).toBeNull();
+  });
+
+  // Does fetching the classes collection work as expected?
+  it("fetching-classes-by-subject-works", async () => {
+    const response = await fetchClassesForSubject(testingEndpoint, "FA20", { descrformal: "The Study of AngryFungi", value: "GORK" });
+    expect(response.length).toBe(2);
+    expect(response[0].subject).toBe("GORK");
+    expect(response[0].catalogNbr).toBe("1110");
+    expect(response[0].titleLong).toBe("Introduction to Angry Fungi");
+    expect(response[1].titleLong).toBe("Advanced Study of Angry Fungi");
+
+    // No FEDN classes, only GORK classes!
+    const nil = await fetchClassesForSubject(testingEndpoint, "FA20", { descrformal: "The Study of Where No One has Gone Before", value: "FEDN" });
+    expect(nil).toBeNull();
+  });
+
+  it("full-scraping-works", async () => {
+    const worked = await fetchAddCourses(testingEndpoint, "FA20");
+    expect(worked).toBe(true);
+
+    // did it add the FEDN subject?
+    expect((await Subjects.findOne({ subShort: "FEDN" }).exec()).subFull).toBe("The Study of Where No One has Gone Before");
+
+    // did it update the semesters on GORK 1110?
+    // notice the .lean(), which changes some of the internals of what mongo returns
+    expect((await Classes.findOne({ classSub: "GORK", classNum: "1110" }).lean().exec()).classSems).toStrictEqual(["FA19", "FA20"]);
+
+    // did it add the GORK 2110 Class?
+    expect((await Classes.findOne({ classSub: "GORK", classNum: "2110" }).exec()).classTitle).toBe("Advanced Study of Angry Fungi");
+  });
+});

--- a/server/dbInit.test.ts
+++ b/server/dbInit.test.ts
@@ -42,7 +42,7 @@ beforeAll(async () => {
 
   // We need to pretend to have access to a cornell classes endpoint
   const app = express();
-  app.listen(1776, async () => {});
+  app.listen(27760, async () => {});
 
   app.get("/hello", (req, res) => {
     res.send("Hello world");
@@ -97,7 +97,7 @@ afterAll(async () => {
   await testServer.stop();
 });
 
-const testingEndpoint = "http://localhost:1776/";
+const testingEndpoint = "http://localhost:27760/";
 
 describe('tests', () => {
   it("dbInit-db-works", async () => {

--- a/server/dbInit.ts
+++ b/server/dbInit.ts
@@ -1,6 +1,6 @@
 import axios from 'axios';
 import shortid from 'shortid';
-import { Classes, Subjects } from './dbDefs';
+import { Classes, Subjects, Professors } from './dbDefs';
 
 export const defaultEndpoint = "https://classes.cornell.edu/api/2.0/";
 
@@ -12,6 +12,28 @@ export interface ScrapingSubject {
   value: string; // Subject code, e.g. "AAS"
 }
 
+// This only exists for compatibility with the API
+export interface ScrapingInstructor {
+  firstName: string;
+  lastName: string;
+}
+
+// This only exists for compatibility with the API
+export interface ScrapingMeeting {
+  instructors: ScrapingInstructor[]
+}
+
+// This only exists for compatibility with the API
+export interface ScrapingClassSection {
+  ssrComponent: string // i.e. LEC, SEM, DIS
+  meetings: ScrapingMeeting[]
+}
+
+// This only exists for compatibility with the API
+export interface ScrapingEnrollGroup {
+  classSections: ScrapingClassSection[] // what sections the class has
+}
+
 // Represents a class which is scraped
 // Note: there's a load of additional information when we scrape it.
 // It's not relevant, so we just ignore it for now.
@@ -19,6 +41,7 @@ export interface ScrapingClass {
   subject: string; // Short: e.g. "CS"
   catalogNbr: string; // e.g. 1110
   titleLong: string; // long variant of a title e.g. "Introduction to Computing Using Python"
+  enrollGroups: ScrapingEnrollGroup[]; // specified by the API
 }
 
 /*
@@ -49,6 +72,37 @@ export async function fetchClassesForSubject(endpoint: string, semester: string,
   return result.data.data.classes;
 }
 
+export function isInstructorEqual(a: ScrapingInstructor, b: ScrapingInstructor) {
+  return a.firstName == b.firstName && a.lastName == b.lastName;
+}
+
+/*
+ * Extract an array of professors from the terribly deeply nested gunk that the api returns
+ * There are guaranteed to be no duplicates!
+ */
+export function extractProfessors(clas: ScrapingClass): ScrapingInstructor[] {
+  const raw = clas.enrollGroups.map(e => e.classSections.map(s => s.meetings.map(m => m.instructors)));
+  // flatmap does not work :(
+  const f1: ScrapingInstructor[][][] = []
+  raw.forEach(r => f1.push(...r));
+  const f2: ScrapingInstructor[][] = []
+  f1.forEach(r => f2.push(...r));
+  const f3: ScrapingInstructor[] = []
+  f2.forEach(r => f3.push(...r));
+
+  let nonDuplicates: ScrapingInstructor[] = [];
+
+  f3.forEach(inst => {
+    // check if there is another instructor in nonDuplicates already!
+    if (nonDuplicates.filter(i => isInstructorEqual(i, inst)).length === 0) {
+      // push the instructor if not present
+      nonDuplicates.push(inst);
+    }
+  });
+
+  return nonDuplicates;
+}
+
 /*
  * Fetch the relevant classes, and add them to the collections
  * Returns true on success, and false on failure.
@@ -57,13 +111,13 @@ export async function fetchAddCourses(endpoint: string, semester: string): Promi
   const subjects = await fetchSubjects(endpoint, semester);
 
   const v1 = await Promise.all(subjects.map(async (subject) => {
-    const subjectIfExists = await Subjects.findOne({ subShort: subject.value.toUpperCase() }).exec();
+    const subjectIfExists = await Subjects.findOne({ subShort: subject.value.toLowerCase() }).exec();
 
     if (!subjectIfExists) {
       console.log(`Adding new subject: ${subject.value}`);
       const res = await new Subjects({
         _id: shortid.generate(),
-        subShort: subject.value.toUpperCase(),
+        subShort: subject.value.toLowerCase(),
         subFull: subject.descrformal,
       }).save().catch((err) => {
         console.log(err);
@@ -96,20 +150,43 @@ export async function fetchAddCourses(endpoint: string, semester: string): Promi
 
     // Update or add all the classes to the collection
     const v = await Promise.all(classes.map(async (cl) => {
-      const classIfExists = await Classes.findOne({ classSub: cl.subject.toUpperCase(), classNum: cl.catalogNbr }).exec();
+      const classIfExists = await Classes.findOne({ classSub: cl.subject.toLowerCase(), classNum: cl.catalogNbr }).exec();
+      const professors = extractProfessors(cl);
+
+      // figure out if the professor already exist in the collection
+      // if not, add to the collection
+      // build a list of professor names to potentially add the the class
+      const profs: string[] = await Promise.all(professors.map(async (p) => {
+        const professorIfExists = await Professors.findOne({ fullName: `${p.firstName} ${p.lastName}`});
+        if (!professorIfExists) {
+
+          const added = await new Professors({
+            _id: shortid.generate(),
+            fullName: `${p.firstName} ${p.lastName}`,
+            courses: [],
+            major: "None" // TODO?
+          });
+
+          return added.fullName;
+        } else {
+          return professorIfExists.fullName;
+        }
+      })).catch(err => {
+        console.log(err);
+        return [];
+      });
 
       // The class does not exist yet, so we add it
       if (!classIfExists) {
         console.log(`Adding new class ${cl.subject} ${cl.catalogNbr}`);
         const res = await new Classes({
           _id: shortid.generate(),
-          classSub: cl.subject.toUpperCase(),
+          classSub: cl.subject.toLowerCase(),
           classNum: cl.catalogNbr,
           classTitle: cl.titleLong,
-          classFull: `${cl.subject.toUpperCase()} ${cl.catalogNbr} ${cl.titleLong}`,
+          classFull: `${cl.subject.toLowerCase()} ${cl.catalogNbr} ${cl.titleLong}`,
           classSems: [semester],
-          // TODO: provide initial values here?
-          classProfessors: null,
+          classProfessors: profs,
           classRating: null,
           classWorkload: null,
           classDifficulty: null,
@@ -128,8 +205,18 @@ export async function fetchAddCourses(endpoint: string, semester: string): Promi
         // Compute the new set of semesters for this class
         const classSems = classIfExists.classSems.indexOf(semester) == -1 ? classIfExists.classSems.concat([semester]) : classIfExists.classSems;
 
+        // Compute the new set of professors for this class
+        let classProfessors = classIfExists.classProfessors ? classIfExists.classProfessors : [];
+
+        // Add any new professors to the class
+        profs.forEach(inst => {
+          if (classProfessors.filter(i => i == inst).length === 0) {
+            classProfessors.push(inst);
+          }
+        });
+
         // update db with new semester information
-        const res = await Classes.findOneAndUpdate({ _id: classIfExists._id }, { $set: { classSems } }).exec()
+        const res = await Classes.findOneAndUpdate({ _id: classIfExists._id }, { $set: { classSems, classProfessors } }).exec()
           .catch((err) => {
             console.log(err);
             return null;
@@ -142,7 +229,10 @@ export async function fetchAddCourses(endpoint: string, semester: string): Promi
       }
 
       return true;
-    })).catch((err) => null);
+    })).catch((err) => {
+      console.log(err);
+      return null;
+    });
 
     // something went wrong updating classes
     if (!v) {

--- a/server/dbInit.ts
+++ b/server/dbInit.ts
@@ -65,7 +65,10 @@ export async function fetchAddCourses(endpoint: string, semester: string): Promi
         _id: shortid.generate(),
         subShort: subject.value.toUpperCase(),
         subFull: subject.descrformal,
-      }).save().catch((err) => null);
+      }).save().catch((err) => {
+        console.log(err);
+        return null;
+      });
 
       // db operation was not successful
       if (!res) {
@@ -110,7 +113,10 @@ export async function fetchAddCourses(endpoint: string, semester: string): Promi
           classRating: null,
           classWorkload: null,
           classDifficulty: null,
-        }).save().catch((err) => { console.log(err); return null; });
+        }).save().catch((err) => {
+          console.log(err);
+          return null;
+        });
 
         if (!res) {
           console.log(`Unable to insert class ${cl.subject} ${cl.catalogNbr}!`);
@@ -124,7 +130,10 @@ export async function fetchAddCourses(endpoint: string, semester: string): Promi
 
         // update db with new semester information
         const res = await Classes.findOneAndUpdate({ _id: classIfExists._id }, { $set: { classSems } }).exec()
-          .catch((err) => null);
+          .catch((err) => {
+            console.log(err);
+            return null;
+          });
 
         if (!res) {
           console.log(`Unable to update class information for ${cl.subject} ${cl.catalogNbr}!`);

--- a/server/dbInit.ts
+++ b/server/dbInit.ts
@@ -20,18 +20,18 @@ export interface ScrapingInstructor {
 
 // This only exists for compatibility with the API
 export interface ScrapingMeeting {
-  instructors: ScrapingInstructor[]
+  instructors: ScrapingInstructor[];
 }
 
 // This only exists for compatibility with the API
 export interface ScrapingClassSection {
-  ssrComponent: string // i.e. LEC, SEM, DIS
-  meetings: ScrapingMeeting[]
+  ssrComponent: string; // i.e. LEC, SEM, DIS
+  meetings: ScrapingMeeting[];
 }
 
 // This only exists for compatibility with the API
 export interface ScrapingEnrollGroup {
-  classSections: ScrapingClassSection[] // what sections the class has
+  classSections: ScrapingClassSection[]; // what sections the class has
 }
 
 // Represents a class which is scraped
@@ -81,20 +81,20 @@ export function isInstructorEqual(a: ScrapingInstructor, b: ScrapingInstructor) 
  * There are guaranteed to be no duplicates!
  */
 export function extractProfessors(clas: ScrapingClass): ScrapingInstructor[] {
-  const raw = clas.enrollGroups.map(e => e.classSections.map(s => s.meetings.map(m => m.instructors)));
+  const raw = clas.enrollGroups.map((e) => e.classSections.map((s) => s.meetings.map((m) => m.instructors)));
   // flatmap does not work :(
-  const f1: ScrapingInstructor[][][] = []
-  raw.forEach(r => f1.push(...r));
-  const f2: ScrapingInstructor[][] = []
-  f1.forEach(r => f2.push(...r));
-  const f3: ScrapingInstructor[] = []
-  f2.forEach(r => f3.push(...r));
+  const f1: ScrapingInstructor[][][] = [];
+  raw.forEach((r) => f1.push(...r));
+  const f2: ScrapingInstructor[][] = [];
+  f1.forEach((r) => f2.push(...r));
+  const f3: ScrapingInstructor[] = [];
+  f2.forEach((r) => f3.push(...r));
 
-  let nonDuplicates: ScrapingInstructor[] = [];
+  const nonDuplicates: ScrapingInstructor[] = [];
 
-  f3.forEach(inst => {
+  f3.forEach((inst) => {
     // check if there is another instructor in nonDuplicates already!
-    if (nonDuplicates.filter(i => isInstructorEqual(i, inst)).length === 0) {
+    if (nonDuplicates.filter((i) => isInstructorEqual(i, inst)).length === 0) {
       // push the instructor if not present
       nonDuplicates.push(inst);
     }
@@ -157,21 +157,19 @@ export async function fetchAddCourses(endpoint: string, semester: string): Promi
       // if not, add to the collection
       // build a list of professor names to potentially add the the class
       const profs: string[] = await Promise.all(professors.map(async (p) => {
-        const professorIfExists = await Professors.findOne({ fullName: `${p.firstName} ${p.lastName}`});
+        const professorIfExists = await Professors.findOne({ fullName: `${p.firstName} ${p.lastName}` });
         if (!professorIfExists) {
-
           const added = await new Professors({
             _id: shortid.generate(),
             fullName: `${p.firstName} ${p.lastName}`,
             courses: [],
-            major: "None" // TODO?
+            major: "None", // TODO?
           });
 
           return added.fullName;
-        } else {
-          return professorIfExists.fullName;
         }
-      })).catch(err => {
+        return professorIfExists.fullName;
+      })).catch((err) => {
         console.log(err);
         return [];
       });
@@ -206,11 +204,11 @@ export async function fetchAddCourses(endpoint: string, semester: string): Promi
         const classSems = classIfExists.classSems.indexOf(semester) == -1 ? classIfExists.classSems.concat([semester]) : classIfExists.classSems;
 
         // Compute the new set of professors for this class
-        let classProfessors = classIfExists.classProfessors ? classIfExists.classProfessors : [];
+        const classProfessors = classIfExists.classProfessors ? classIfExists.classProfessors : [];
 
         // Add any new professors to the class
-        profs.forEach(inst => {
-          if (classProfessors.filter(i => i == inst).length === 0) {
+        profs.forEach((inst) => {
+          if (classProfessors.filter((i) => i == inst).length === 0) {
             classProfessors.push(inst);
           }
         });

--- a/server/dbInit.ts
+++ b/server/dbInit.ts
@@ -26,7 +26,7 @@ export interface ScrapingClass {
  * Returns the class roster on success, or null if there was an error.
  */
 export async function fetchSubjects(endpoint: string, semester: string): Promise<ScrapingSubject[]> {
-  const result = await axios.get(`${endpoint}config/subjects.json?roster=${semester}`, { timeout: 10 });
+  const result = await axios.get(`${endpoint}config/subjects.json?roster=${semester}`, { timeout: 10000 });
   if (result.status !== 200 || result.data.status !== "success") {
     console.log(`Error fetching ${semester} subjects! HTTP: ${result.statusText} SERV: ${result.data.status}`);
     return null;
@@ -40,7 +40,7 @@ export async function fetchSubjects(endpoint: string, semester: string): Promise
  * Returns a list of classes on success, or null if there was an error.
  */
 export async function fetchClassesForSubject(endpoint: string, semester: string, subject: ScrapingSubject): Promise<ScrapingClass[]> {
-  const result = await axios.get(`${endpoint}search/classes.json?roster=${semester}&subject=${subject.value}`, { timeout: 10 });
+  const result = await axios.get(`${endpoint}search/classes.json?roster=${semester}&subject=${subject.value}`, { timeout: 10000 });
   if (result.status !== 200 || result.data.status !== "success") {
     console.log(`Error fetching subject ${semester}-${subject.value} classes! HTTP: ${result.statusText} SERV: ${result.data.status}`);
     return null;

--- a/server/methods.ts
+++ b/server/methods.ts
@@ -82,51 +82,59 @@ Meteor.methods({
    * Returns 1 on a success
    */
   async insert(token, review, classId) {
-    if (token == undefined) {
-      console.log("Error: Token was undefined in insert");
-      return 0;
-    }
+    try {
+      if (token === undefined) {
+        console.log("Error: Token was undefined in insert");
+        return 0;
+      }
 
-    const ticket = await Meteor.call<TokenPayload | null>("getVerificationTicket", token);
+      const ticket = await Meteor.call<TokenPayload | null>("getVerificationTicket", token);
 
-    if (!ticket) return 0;
+      if (!ticket) return 0;
 
-    if (ticket.hd === "cornell.edu") {
-      // insert the user into the collection if not already present
-      await Meteor.call("insertUser", ticket);
+      if (ticket.hd === "cornell.edu") {
+        // insert the user into the collection if not already present
+        await Meteor.call("insertUser", ticket);
 
-      if (review.text !== null && review.diff !== null && review.rating !== null
+        if (review.text !== null && review.diff !== null && review.rating !== null
           && review.workload !== null && review.professors !== null && classId !== undefined
           && classId !== null) {
-        try {
-          // Attempt to insert the review
-          const fullReview = new Reviews({
-            _id: shortid.generate(),
-            text: review.text,
-            difficulty: review.diff,
-            rating: review.rating,
-            workload: review.workload,
-            class: classId,
-            date: new Date(),
-            visible: 0,
-            reported: 0,
-            professors: review.professors,
-            likes: 0,
-            virtual: true,
-          });
+          try {
+            // Attempt to insert the review
+            const fullReview = new Reviews({
+              _id: shortid.generate(),
+              text: review.text,
+              difficulty: review.diff,
+              rating: review.rating,
+              workload: review.workload,
+              class: classId,
+              date: new Date(),
+              visible: 0,
+              reported: 0,
+              professors: review.professors,
+              likes: 0,
+              virtual: true,
+            });
 
-          await fullReview.save();
-          return 1;
-        } catch (error) {
-          console.log(error);
+            await fullReview.save();
+            return 1;
+          } catch (error) {
+            console.log(error);
+            return 0;
+          }
+        } else {
+          console.log("Error: Some review values are null");
           return 0;
         }
       } else {
-        console.log("Error: Some review values are null");
+        console.log("Error: non-Cornell email attempted to insert review");
         return 0;
       }
-    } else {
-      console.log("Error: non-Cornell email attempted to insert review");
+    } catch (error) {
+      // eslint-disable-next-line no-console
+      console.log("Error: at 'insert' method");
+      // eslint-disable-next-line no-console
+      console.log(error);
       return 0;
     }
   },
@@ -138,11 +146,11 @@ Meteor.methods({
    * Returns 0 if there was an error
    */
   async insertUser(googleObject) {
-    // Check user object has all required fields
-    if (googleObject.email.replace("@cornell.edu", "") != null) {
-      const user = await Meteor.call<StudentDocument | null>("getUserByNetId", googleObject.email.replace("@cornell.edu", ""));
-      if (user == null) {
-        try {
+    try {
+      // Check user object has all required fields
+      if (googleObject.email.replace("@cornell.edu", "") !== null) {
+        const user = await Meteor.call<StudentDocument | null>("getUserByNetId", googleObject.email.replace("@cornell.edu", ""));
+        if (user === null) {
           const newUser = new Students({
             _id: shortid.generate(),
             // Check to see if Google returns first and last name
@@ -156,19 +164,19 @@ Meteor.methods({
           });
 
           await newUser.save();
-          return 1;
-        } catch (error) {
-          console.log("Error: In inserting Student");
-          console.log(error);
-          return 0;
         }
-      } else {
         return 1;
       }
-    }
 
-    console.log("Error: Some user values are null in insertUser");
-    return 0;
+      console.log("Error: Some user values are null in insertUser");
+      return 0;
+    } catch (error) {
+      // eslint-disable-next-line no-console
+      console.log("Error: at 'insertUser' method");
+      // eslint-disable-next-line no-console
+      console.log(error);
+      return 0;
+    }
   },
   /**
    * Increment the number of likes a review has gotten by 1.
@@ -179,13 +187,17 @@ Meteor.methods({
   async incrementLike(id) {
     try {
       const review = await Reviews.findOne({ _id: id }).exec();
-      if (review.likes == undefined) {
+      if (review.likes === undefined) {
         await Reviews.updateOne({ _id: id }, { $set: { likes: 1 } }).exec();
       } else {
         await Reviews.updateOne({ _id: id }, { $set: { likes: review.likes + 1 } }).exec();
       }
       return 1;
     } catch (error) {
+      // eslint-disable-next-line no-console
+      console.log("Error: at 'incrementLike' method");
+      // eslint-disable-next-line no-console
+      console.log(error);
       return 0;
     }
   },
@@ -199,83 +211,117 @@ Meteor.methods({
   async decrementLike(id) {
     try {
       const review = await Reviews.findOne({ _id: id }).exec();
-      if (review.likes == undefined) {
+      if (review.likes === undefined) {
         await Reviews.updateOne({ _id: id }, { $set: { likes: 0 } }).exec();
       } else {
         await Reviews.updateOne({ _id: id }, { $set: { likes: review.likes - 1 } }).exec();
       }
       return 1;
     } catch (error) {
+      // eslint-disable-next-line no-console
+      console.log("Error: at 'decrementLike' method");
+      // eslint-disable-next-line no-console
+      console.log(error);
       return 0;
     }
   },
 
-  // Make this reveiw visible to everyone (ex: un-report a review)
+  // Make this review visible to everyone (ex: un-report or approve a review)
   // Upon succcess, return 1, else 0.
   async makeVisible(review, token) {
-    // check: make sure review id is valid and non-malicious
-    const userIsAdmin = await Meteor.call("tokenIsAdmin", token);
-    const regex = new RegExp(/^(?=.*[A-Z0-9])/i);
-    if (regex.test(review._id) && userIsAdmin) {
-      await Reviews.updateOne({ _id: review._id }, { $set: { visible: 1 } });
-      await Meteor.call("updateCourseMetrics", review.class, token);
-      return 1;
+    try {
+      // check: make sure review id is valid and non-malicious
+      const userIsAdmin = await Meteor.call("tokenIsAdmin", token);
+      const regex = new RegExp(/^(?=.*[A-Z0-9])/i);
+      if (regex.test(review._id) && userIsAdmin) {
+        await Reviews.updateOne({ _id: review._id }, { $set: { visible: 1 } });
+        await Meteor.call("updateCourseMetrics", review.class, token);
+        return 1;
+      }
+    } catch (error) {
+      // eslint-disable-next-line no-console
+      console.log("Error: at 'makeVisible' method");
+      // eslint-disable-next-line no-console
+      console.log(error);
+      return 0;
     }
-    return 0;
   },
 
   // Delete this review from the local database.
   // Upon succcess, return 1, else 0.
   async removeReview(review, token) {
-    // check: make sure review id is valid and non-malicious
-    const userIsAdmin = await Meteor.call("tokenIsAdmin", token);
-    const regex = new RegExp(/^(?=.*[A-Z0-9])/i);
-    if (regex.test(review._id) && userIsAdmin) {
-      await Reviews.remove({ _id: review._id });
-      await Meteor.call("updateCourseMetrics", review.class, token);
-      return 1;
+    try {
+      // check: make sure review id is valid and non-malicious
+      const userIsAdmin = await Meteor.call("tokenIsAdmin", token);
+      const regex = new RegExp(/^(?=.*[A-Z0-9])/i);
+      if (regex.test(review._id) && userIsAdmin) {
+        await Reviews.remove({ _id: review._id });
+        await Meteor.call("updateCourseMetrics", review.class, token);
+        return 1;
+      }
+      return 0;
+    } catch (error) {
+      // eslint-disable-next-line no-console
+      console.log("Error: at 'removeReview' method");
+      // eslint-disable-next-line no-console
+      console.log(error);
+      return 0;
     }
-    return 0;
   },
 
   // This updates the metrics for an individual class given its Mongo-generated id.
   // Returns 1 if successful, 0 otherwise.
   async updateCourseMetrics(courseId, token) {
-    const userIsAdmin = await Meteor.call("tokenIsAdmin", token);
-    if (userIsAdmin) {
-      const course = await Meteor.call("getCourseById", courseId);
-      if (course) {
-        const crossListOR = getCrossListOR(course);
-        const reviews = await Reviews.find({ visible: 1, reported: 0, $or: crossListOR }, {}, { sort: { date: -1 }, limit: 700 }).exec();
-        const state = getGaugeValues(reviews);
+    try {
+      const userIsAdmin = await Meteor.call("tokenIsAdmin", token);
+      if (userIsAdmin) {
+        const course = await Meteor.call("getCourseById", courseId);
+        if (course) {
+          const crossListOR = getCrossListOR(course);
+          const reviews = await Reviews.find({ visible: 1, reported: 0, $or: crossListOR }, {}, { sort: { date: -1 }, limit: 700 }).exec();
+          const state = getGaugeValues(reviews);
 
-        await Classes.updateOne({ _id: courseId },
-          {
-            $set: {
-              // If no data is available, getGaugeValues returns "-" for metric
-              classDifficulty: (state.diff !== "-" ? Number(state.diff) : null),
-              classRating: (state.rating !== "-" ? Number(state.rating) : null),
-              classWorkload: (state.workload !== "-" ? Number(state.workload) : null),
-            },
-          });
-        return 1;
+          await Classes.updateOne({ _id: courseId },
+            {
+              $set: {
+                // If no data is available, getGaugeValues returns "-" for metric
+                classDifficulty: (state.diff !== "-" ? Number(state.diff) : null),
+                classRating: (state.rating !== "-" ? Number(state.rating) : null),
+                classWorkload: (state.workload !== "-" ? Number(state.workload) : null),
+              },
+            });
+          return 1;
+        }
+        return 0;
       }
       return 0;
+    } catch (error) {
+      // eslint-disable-next-line no-console
+      console.log("Error: at 'updateCourseMetrics' method");
+      // eslint-disable-next-line no-console
+      console.log(error);
+      return 0;
     }
-
-    return 0;
   },
   // Used to update the review metrics for all courses
   // in the database.
   async updateMetricsForAllCourses(token) {
-    const userIsAdmin = await Meteor.call("tokenIsAdmin", token);
-    if (userIsAdmin) {
-      console.log("Starting update for metrics");
-      const courses = await Classes.find().exec();
-      await Promise.all(courses.map(async (course) => {
-        await Meteor.call("updateCourseMetrics", course._id);
-      }));
-      console.log("Updated metrics for all courses");
+    try {
+      const userIsAdmin = await Meteor.call("tokenIsAdmin", token);
+      if (userIsAdmin) {
+        console.log("Starting update for metrics");
+        const courses = await Classes.find().exec();
+        await Promise.all(courses.map(async (course) => {
+          await Meteor.call("updateCourseMetrics", course._id);
+        }));
+        console.log("Updated metrics for all courses");
+      }
+    } catch (error) {
+      // eslint-disable-next-line no-console
+      console.log("Error: at 'updateMetricsForAllCourses' method");
+      // eslint-disable-next-line no-console
+      console.log(error);
+      return 0;
     }
   },
 
@@ -288,14 +334,22 @@ Meteor.methods({
   // NOTE/TODO: I don't think this actually works as intended
   // let's refactor in future - Julian
   async getCoursesByFilters(parameters) {
-    let courses = [];
-    const regex = new RegExp(/^(?=.*[A-Z0-9])/i);
-    // TODO: add regular expression for floating point numbers
-    for (const key in parameters) {
-      if (!regex.test(key)) return courses;
+    try {
+      let courses = [];
+      const regex = new RegExp(/^(?=.*[A-Z0-9])/i);
+      // TODO: add regular expression for floating point numbers
+      for (const key in parameters) {
+        if (!regex.test(key)) return courses;
+      }
+      courses = await Classes.find(parameters).exec();
+      return courses;
+    } catch (error) {
+      // eslint-disable-next-line no-console
+      console.log("Error: at 'getCoursesByFilters' method");
+      // eslint-disable-next-line no-console
+      console.log(error);
+      return null;
     }
-    courses = await Classes.find(parameters).exec();
-    return courses;
   },
 
   // Returns courses with the given parameters.
@@ -303,12 +357,20 @@ Meteor.methods({
   // e.g. CS, INFO, PHIL
   // Returns an empty array if no classes match.
   async getCoursesByMajor(major) {
-    let courses = [];
-    const regex = new RegExp(/^(?=.*[A-Z0-9])/i);
-    if (regex.test(major)) {
-      courses = await Classes.find({ classSub: major }).exec();
+    try {
+      let courses = [];
+      const regex = new RegExp(/^(?=.*[A-Z0-9])/i);
+      if (regex.test(major)) {
+        courses = await Classes.find({ classSub: major }).exec();
+      }
+      return courses;
+    } catch (error) {
+      // eslint-disable-next-line no-console
+      console.log("Error: at 'getCoursesByMajor' method");
+      // eslint-disable-next-line no-console
+      console.log(error);
+      return null;
     }
-    return courses;
   },
 
   // Returns courses with the given parameters.
@@ -316,12 +378,20 @@ Meteor.methods({
   // e.g. David Gries, Michael George
   // Returns an empty array if no classes match.
   async getCoursesByProfessor(professor) {
-    let courses = [];
-    const regex = new RegExp(/^(?=.*[A-Z0-9])/i);
-    if (regex.test(professor)) {
-      courses = await Classes.find({ classProfessors: professor }).exec();
+    try {
+      let courses = [];
+      const regex = new RegExp(/^(?=.*[A-Z0-9])/i);
+      if (regex.test(professor)) {
+        courses = await Classes.find({ classProfessors: professor }).exec();
+      }
+      return courses;
+    } catch (error) {
+      // eslint-disable-next-line no-console
+      console.log("Error: at 'getCoursesByProfessor' method");
+      // eslint-disable-next-line no-console
+      console.log(error);
+      return null;
     }
-    return courses;
   },
 
   // Update the local database when Cornell Course API adds data for the
@@ -383,425 +453,573 @@ Meteor.methods({
   /* Update the database so we have the professors information.
   This calls updateProfessors in dbInit */
   async setProfessors(initiate, token) {
-    const userIsAdmin = await Meteor.call("tokenIsAdmin", token);
-    if (initiate && userIsAdmin) {
-      const semesters = findAllSemesters();
-
-      console.log("These are the semesters");
-      console.log(semesters);
-      const val = updateProfessors(semesters);
-      if (val) {
-        return val;
+    try {
+      const userIsAdmin = await Meteor.call("tokenIsAdmin", token);
+      if (initiate && userIsAdmin) {
+        const semesters = findAllSemesters();
+        console.log("These are the semesters");
+        console.log(semesters);
+        const val = updateProfessors(semesters);
+        if (val) {
+          return val;
+        }
+        console.log("fail at setProfessors in method.js");
+        return 0;
       }
-      console.log("fail at setProfessors in method.js");
+      return 0;
+    } catch (error) {
+      // eslint-disable-next-line no-console
+      console.log("Error: at 'setProfessors' method");
+      // eslint-disable-next-line no-console
+      console.log(error);
       return 0;
     }
-    return 0;
   },
 
   /* Initializes the classProfessors field in the Classes collection to an empty array so that
   we have a uniform empty array to fill with updateProfessors
   This calls the resetProfessorArray in dbInit */
   async resetProfessors(initiate, token) {
-    const userIsAdmin = await Meteor.call("tokenIsAdmin", token);
-    if (initiate && userIsAdmin) {
-      const semesters = findAllSemesters();
-
-      console.log("These are the semesters");
-      console.log(semesters);
-      const val = resetProfessorArray(semesters);
-      if (val) {
-        return val;
+    try {
+      const userIsAdmin = await Meteor.call("tokenIsAdmin", token);
+      if (initiate && userIsAdmin) {
+        const semesters = findAllSemesters();
+        console.log("These are the semesters");
+        console.log(semesters);
+        const val = resetProfessorArray(semesters);
+        if (val) {
+          return val;
+        }
+        console.log("fail at resetProfessors in method.js");
+        return 0;
       }
-      console.log("fail at resetProfessors in method.js");
+      return 0;
+    } catch (error) {
+      // eslint-disable-next-line no-console
+      console.log("Error: at 'resetProfessors' method");
+      // eslint-disable-next-line no-console
+      console.log(error);
       return 0;
     }
-    return 0;
   },
 
   // Get a user with this netId from the Users collection in the local database
   async getUserByNetId(netId: string) {
-    const regex = new RegExp(/^(?=.*[A-Z0-9])/i);
-    if (regex.test(netId)) {
-      try {
+    try {
+      const regex = new RegExp(/^(?=.*[A-Z0-9])/i);
+      if (regex.test(netId)) {
         return await Students.findOne({ netId }).exec();
-      } catch (error) {
-        console.log(error);
-        return null;
       }
+      return null;
+    } catch (error) {
+      // eslint-disable-next-line no-console
+      console.log("Error: at 'getUserByNetId' method");
+      // eslint-disable-next-line no-console
+      console.log(error);
+      return null;
     }
-    return null;
   },
 
   // Returns true if user matching "netId" is an admin
   async tokenIsAdmin(token: string) {
-    if (token != null) {
-      const ticket = await Meteor.call<TokenPayload | null>('getVerificationTicket', token);
-      if (ticket && ticket.email) {
-        const user = await Meteor.call<StudentDocument | null>('getUserByNetId', ticket.email.replace('@cornell.edu', ''));
-        if (user) {
-          return user.privilege === 'admin';
+    try {
+      if (token != null) {
+        const ticket = await Meteor.call<TokenPayload | null>('getVerificationTicket', token);
+        if (ticket && ticket.email) {
+          const user = await Meteor.call<StudentDocument | null>('getUserByNetId', ticket.email.replace('@cornell.edu', ''));
+          if (user) {
+            return user.privilege === 'admin';
+          }
         }
       }
+      return false;
+    } catch (error) {
+      // eslint-disable-next-line no-console
+      console.log("Error: at 'tokenIsAdmin' method");
+      // eslint-disable-next-line no-console
+      console.log(error);
+      return false;
     }
-    return false;
   },
 
   async getClassesByQuery(searchString: string) {
-    if (searchString !== undefined && searchString !== '') {
-      // check if first digit is a number. Catches searchs like "1100"
-      // if so, search only through the course numbers and return classes ordered by full name
-      const indexFirstDigit = searchString.search(/\d/);
-      if (indexFirstDigit === 0) {
-        // console.log("only numbers")
+    try {
+      if (searchString !== undefined && searchString !== '') {
+        // check if first digit is a number. Catches searchs like "1100"
+        // if so, search only through the course numbers and return classes ordered by full name
+        const indexFirstDigit = searchString.search(/\d/);
+        if (indexFirstDigit === 0) {
+          // console.log("only numbers")
+          return Classes.find(
+            { classNum: { $regex: `.*${searchString}.*`, $options: '-i' } },
+            {},
+            { sort: { classFull: 1 }, limit: 200, reactive: false },
+          ).exec().then((classes) => classes.sort(courseSort(searchString)));
+        }
+
+        // check if searchString is a subject, if so return only classes with this subject. Catches searches like "CS"
+        if (await isSubShorthand(searchString)) {
+          return Classes.find({ classSub: searchString }, {}, { sort: { classFull: 1 }, limit: 200, reactive: false }).exec();
+        }
+        // check if text before space is subject, if so search only classes with this subject.
+        // Speeds up searches like "CS 1110"
+        const indexFirstSpace = searchString.search(' ');
+        if (indexFirstSpace !== -1) {
+          const strBeforeSpace = searchString.substring(0, indexFirstSpace);
+          const strAfterSpace = searchString.substring(indexFirstSpace + 1);
+          if (await isSubShorthand(strBeforeSpace)) {
+            // console.log("matches subject with space: " + strBeforeSpace)
+            return await searchWithinSubject(strBeforeSpace, strAfterSpace);
+          }
+        }
+
+        // check if text is subject followed by course number (no space)
+        // if so search only classes with this subject.
+        // Speeds up searches like "CS1110"
+        if (indexFirstDigit !== -1) {
+          const strBeforeDigit = searchString.substring(0, indexFirstDigit);
+          const strAfterDigit = searchString.substring(indexFirstDigit);
+          if (await isSubShorthand(strBeforeDigit)) {
+            // console.log("matches subject with digit: " + String(strBeforeDigit))
+            return await searchWithinSubject(strBeforeDigit, strAfterDigit);
+          }
+        }
+
+        // last resort, search everything
+        // console.log("nothing matches");
         return Classes.find(
-          { classNum: { $regex: `.*${searchString}.*`, $options: '-i' } },
-          {},
-          { sort: { classFull: 1 }, limit: 200, reactive: false },
-        ).exec().then((classes) => classes.sort(courseSort(searchString)));
+          { classFull: { $regex: `.*${searchString}.*`, $options: '-i' } },
+          {}, { sort: { classFull: 1 }, limit: 200, reactive: false },
+        ).exec();
       }
-
-      // check if searchString is a subject, if so return only classes with this subject. Catches searches like "CS"
-      if (await isSubShorthand(searchString)) {
-        return Classes.find({ classSub: searchString }, {}, { sort: { classFull: 1 }, limit: 200, reactive: false }).exec();
-      }
-      // check if text before space is subject, if so search only classes with this subject.
-      // Speeds up searches like "CS 1110"
-      const indexFirstSpace = searchString.search(' ');
-      if (indexFirstSpace !== -1) {
-        const strBeforeSpace = searchString.substring(0, indexFirstSpace);
-        const strAfterSpace = searchString.substring(indexFirstSpace + 1);
-        if (await isSubShorthand(strBeforeSpace)) {
-          // console.log("matches subject with space: " + strBeforeSpace)
-          return await searchWithinSubject(strBeforeSpace, strAfterSpace);
-        }
-      }
-
-      // check if text is subject followed by course number (no space)
-      // if so search only classes with this subject.
-      // Speeds up searches like "CS1110"
-      if (indexFirstDigit !== -1) {
-        const strBeforeDigit = searchString.substring(0, indexFirstDigit);
-        const strAfterDigit = searchString.substring(indexFirstDigit);
-        if (await isSubShorthand(strBeforeDigit)) {
-          // console.log("matches subject with digit: " + String(strBeforeDigit))
-          return await searchWithinSubject(strBeforeDigit, strAfterDigit);
-        }
-      }
-
-      // last resort, search everything
-      // console.log("nothing matches");
-      return Classes.find(
-        { classFull: { $regex: `.*${searchString}.*`, $options: '-i' } },
-        {}, { sort: { classFull: 1 }, limit: 200, reactive: false },
-      ).exec();
+      // console.log("no search");
+      return Classes.find({}, {}, { sort: { classFull: 1 }, limit: 200, reactive: false }).exec();
+    } catch (error) {
+      // eslint-disable-next-line no-console
+      console.log("Error: at 'getClassesByQuery' method");
+      // eslint-disable-next-line no-console
+      console.log(error);
+      return null;
     }
-    // console.log("no search");
-    return Classes.find({}, {}, { sort: { classFull: 1 }, limit: 200, reactive: false }).exec();
   },
 
   // Get a course with this course_id from the Classes collection in the local database.
   async getCourseById(courseId) {
-    // check: make sure course id is valid and non-malicious
-    const regex = new RegExp(/^(?=.*[A-Z0-9])/i);
-    if (regex.test(courseId)) {
-      return await Classes.findOne({ _id: courseId }).exec();
+    try {
+      // check: make sure course id is valid and non-malicious
+      const regex = new RegExp(/^(?=.*[A-Z0-9])/i);
+      if (regex.test(courseId)) {
+        return await Classes.findOne({ _id: courseId }).exec();
+      }
+      return null;
+    } catch (error) {
+      // eslint-disable-next-line no-console
+      console.log("Error: at 'getCourseById' method");
+      // eslint-disable-next-line no-console
+      console.log(error);
+      return null;
     }
-    return null;
   },
 
   // Get a course with this course number and subject from the Classes collection in the local database.
   async getCourseByInfo(number: string, subject: string) {
-    // check: make sure number and subject are valid, non-malicious strings
-    const numberRegex = new RegExp(/^(?=.*[0-9])/i);
-    const subjectRegex = new RegExp(/^(?=.*[A-Z])/i);
-    if (numberRegex.test(number) && subjectRegex.test(subject)) {
-      return await Classes.findOne({ classSub: subject, classNum: number }).exec();
-    }
+    try {
+      // check: make sure number and subject are valid, non-malicious strings
+      const numberRegex = new RegExp(/^(?=.*[0-9])/i);
+      const subjectRegex = new RegExp(/^(?=.*[A-Z])/i);
+      if (numberRegex.test(number) && subjectRegex.test(subject)) {
+        return await Classes.findOne({ classSub: subject, classNum: number }).exec();
+      }
 
-    return null;
+      return null;
+    } catch (error) {
+      // eslint-disable-next-line no-console
+      console.log("Error: at 'getCourseByInfo' method");
+      // eslint-disable-next-line no-console
+      console.log(error);
+      return null;
+    }
   },
 
   // Searches the database on Classes's text index and returns matching courses
   async getCoursesByKeyword(keyword: string) {
-    const regex = new RegExp(/^(?=.*[A-Z0-9])/i);
-    if (regex.test(keyword)) {
-      return (await Classes.find({ $text: { $search: keyword } }, { score: { $meta: "textScore" } }, { sort: { score: { $meta: "textScore" } } }).exec())
-        .sort(courseSort(keyword));
+    try {
+      const regex = new RegExp(/^(?=.*[A-Z0-9])/i);
+      if (regex.test(keyword)) {
+        return (await Classes.find({ $text: { $search: keyword } }, { score: { $meta: "textScore" } }, { sort: { score: { $meta: "textScore" } } }).exec())
+          .sort(courseSort(keyword));
+      }
+      return null;
+    } catch (error) {
+      // eslint-disable-next-line no-console
+      console.log("Error: at 'getCoursesByKeyword' method");
+      // eslint-disable-next-line no-console
+      console.log(error);
+      return null;
     }
-    return null;
   },
 
   // Searches the database on Subjects's text index and returns matching subjects (which we're equating to majors)
   async getSubjectsByKeyword(keyword: string) {
-    const regex = new RegExp(/^(?=.*[A-Z0-9])/i);
-    if (regex.test(keyword)) {
-      return await Subjects.find({ $text: { $search: keyword } }, { score: { $meta: "textScore" } }, { sort: { score: { $meta: "textScore" } } }).exec();
+    try {
+      const regex = new RegExp(/^(?=.*[A-Z0-9])/i);
+      if (regex.test(keyword)) {
+        return await Subjects.find({ $text: { $search: keyword } }, { score: { $meta: "textScore" } }, { sort: { score: { $meta: "textScore" } } }).exec();
+      }
+      return null;
+    } catch (error) {
+      // eslint-disable-next-line no-console
+      console.log("Error: at 'getSubjectsByKeyword' method");
+      // eslint-disable-next-line no-console
+      console.log(error);
+      return null;
     }
-    return null;
   },
 
   // Searches the database on Professors's text index and returns matching professors
   async getProfessorsByName(name: string) {
-    const regex = new RegExp(/^(?=.*[A-Z0-9])/i);
-    if (regex.test(name)) {
-      return await Professors.find({ $text: { $search: name } }, { score: { $meta: "textScore" } }, { sort: { score: { $meta: "textScore" } } }).exec();
+    try {
+      const regex = new RegExp(/^(?=.*[A-Z0-9])/i);
+      if (regex.test(name)) {
+        return await Professors.find({ $text: { $search: name } }, { score: { $meta: "textScore" } }, { sort: { score: { $meta: "textScore" } } }).exec();
+      }
+      return null;
+    } catch (error) {
+      // eslint-disable-next-line no-console
+      console.log("Error: at 'getProfessorsByName' method");
+      // eslint-disable-next-line no-console
+      console.log(error);
+      return null;
     }
-    return null;
   },
 
   // Flag a review - mark it as reported and make it invisible to non-admin users.
   // To be called by a non-admin user from a specific review.
   async reportReview(review) {
-    // check: make sure review id is valid and non-malicious
-    const regex = new RegExp(/^(?=.*[A-Z0-9])/i);
-    if (regex.test(review._id)) {
-      await Reviews.updateOne({ _id: review._id }, { $set: { visible: 0, reported: 1 } });
-      return 1;
+    try {
+      // check: make sure review id is valid and non-malicious
+      const regex = new RegExp(/^(?=.*[A-Z0-9])/i);
+      if (regex.test(review._id)) {
+        await Reviews.updateOne({ _id: review._id }, { $set: { visible: 0, reported: 1 } });
+        return 1;
+      }
+      return 0;
+    } catch (error) {
+      // eslint-disable-next-line no-console
+      console.log("Error: at 'reportReview' method");
+      // eslint-disable-next-line no-console
+      console.log(error);
+      return 0;
     }
-    return 0;
   },
 
   // Un-flag a review, making it visible to everyone and "unreported"
   // To be called by an admin via the admin interface.
   async undoReportReview(review, token) {
-    const userIsAdmin = await Meteor.call("tokenIsAdmin", token);
-    // check: make sure review id is valid and non-malicious
-    const regex = new RegExp(/^(?=.*[A-Z0-9])/i);
-    if (regex.test(review._id) && userIsAdmin) {
-      await Reviews.updateOne({ _id: review._id }, { $set: { visible: 1, reported: 0 } });
-      return 1;
+    try {
+      const userIsAdmin = await Meteor.call("tokenIsAdmin", token);
+      // check: make sure review id is valid and non-malicious
+      const regex = new RegExp(/^(?=.*[A-Z0-9])/i);
+      if (regex.test(review._id) && userIsAdmin) {
+        await Reviews.updateOne({ _id: review._id }, { $set: { visible: 1, reported: 0 } });
+        return 1;
+      }
+      return 0;
+    } catch (error) {
+      // eslint-disable-next-line no-console
+      console.log("Error: at 'undoReportReview' method");
+      // eslint-disable-next-line no-console
+      console.log(error);
+      return 0;
     }
-    return 0;
   },
 
   // get all reviews by professor
   async getReviewsByProfessor(professor: string) {
-    const regex = new RegExp(/^(?=.*[A-Z])/i);
-    if (regex.test(professor)) {
-      return await Reviews.find({ professors: { $elemMatch: { $eq: professor } } }).exec();
+    try {
+      const regex = new RegExp(/^(?=.*[A-Z])/i);
+      if (regex.test(professor)) {
+        return await Reviews.find({ professors: { $elemMatch: { $eq: professor } } }).exec();
+      }
+      return null;
+    } catch (error) {
+      // eslint-disable-next-line no-console
+      console.log("Error: at 'getReviewsByProfessor' method");
+      // eslint-disable-next-line no-console
+      console.log(error);
+      return null;
     }
-    return null;
   },
 
   // Get list of review objects for given class from class _id
   // Accounts for cross-listed reviews
   async getReviewsByCourseId(courseId: string) {
-    const regex = new RegExp(/^(?=.*[A-Z])/i);
-    if (regex.test(courseId)) {
-      const course = await Meteor.call("getCourseById", courseId);
-      if (course) {
-        const crossListOR = getCrossListOR(course);
-        const reviews = await Reviews.find({ visible: 1, reported: 0, $or: crossListOR }, {}, { sort: { date: -1 }, limit: 700 }).exec();
-        return reviews;
+    try {
+      const regex = new RegExp(/^(?=.*[A-Z])/i);
+      if (regex.test(courseId)) {
+        const course = await Meteor.call("getCourseById", courseId);
+        if (course) {
+          const crossListOR = getCrossListOR(course);
+          const reviews = await Reviews.find({ visible: 1, reported: 0, $or: crossListOR }, {}, { sort: { date: -1 }, limit: 700 }).exec();
+          return reviews;
+        }
+        return null;
       }
-
+      return null;
+    } catch (error) {
+      // eslint-disable-next-line no-console
+      console.log("Error: at 'getReviewsByCourseId' method");
+      // eslint-disable-next-line no-console
+      console.log(error);
       return null;
     }
-    return null;
   },
 
   // get all classes by professor
   async getClassesByProfessor(professor: string) {
-    const regex = new RegExp(/^(?=.*[A-Z])/i);
-    if (regex.test(professor)) {
-      return Classes.find({ classProfessors: { $elemMatch: { $eq: professor } } }).exec();
+    try {
+      const regex = new RegExp(/^(?=.*[A-Z])/i);
+      if (regex.test(professor)) {
+        return Classes.find({ classProfessors: { $elemMatch: { $eq: professor } } }).exec();
+      }
+      return null;
+    } catch (error) {
+      // eslint-disable-next-line no-console
+      console.log("Error: at 'getClassesByProfessor' method");
+      // eslint-disable-next-line no-console
+      console.log(error);
+      return null;
     }
-    return null;
   },
 
   // Get a list the most popular courses from the Classes collection (objects)
   // popular classes -> most reviewed.
   async topSubjects() {
-    // using the add-on library meteorhacks:aggregate, define pipeline aggregate functions
-    // to run complex queries
-    const pipeline = [
-      // consider only visible reviews
-      { $match: { visible: 1 } },
-      // group by class and get count of reviews
-      { $group: { _id: '$class', reviewCount: { $sum: 1 } } },
-      // sort by decending count
-      // {$sort: {"reviewCount": -1}},
-      // {$limit: 10}
-    ];
-    // reviewedSubjects is a dictionary-like object of subjects (key) and
-    // number of reviews (value) associated with that subject
-    const reviewedSubjects = new DefaultDict();
-    // run the query and return the class name and number of reviews written to it
-    const results = await Reviews.aggregate<{ reviewCount: number; _id: string }>(pipeline, () => {});
+    try {
+      // using the add-on library meteorhacks:aggregate, define pipeline aggregate functions
+      // to run complex queries
+      const pipeline = [
+        // consider only visible reviews
+        { $match: { visible: 1 } },
+        // group by class and get count of reviews
+        { $group: { _id: '$class', reviewCount: { $sum: 1 } } },
+        // sort by decending count
+        // {$sort: {"reviewCount": -1}},
+        // {$limit: 10}
+      ];
+      // reviewedSubjects is a dictionary-like object of subjects (key) and
+      // number of reviews (value) associated with that subject
+      const reviewedSubjects = new DefaultDict();
+      // run the query and return the class name and number of reviews written to it
+      const results = await Reviews.aggregate<{ reviewCount: number; _id: string }>(pipeline, () => { });
 
-    await Promise.all(results.map(async (course) => {
-      const classObject = (await Classes.find({ _id: course._id }).exec())[0];
-      // classSubject is the string of the full subject of classObject
-      const subjectArr = await Subjects.find({ subShort: classObject.classSub }).exec();
-      if (subjectArr.length > 0) {
-        const classSubject = subjectArr[0].subFull;
-        // Adds the number of reviews to the ongoing count of reviews per subject
-        const curVal = reviewedSubjects.get(classSubject) || 0;
-        reviewedSubjects[classSubject] = curVal + course.reviewCount;
-      }
-    }));
+      await Promise.all(results.map(async (course) => {
+        const classObject = (await Classes.find({ _id: course._id }).exec())[0];
+        // classSubject is the string of the full subject of classObject
+        const subjectArr = await Subjects.find({ subShort: classObject.classSub }).exec();
+        if (subjectArr.length > 0) {
+          const classSubject = subjectArr[0].subFull;
+          // Adds the number of reviews to the ongoing count of reviews per subject
+          const curVal = reviewedSubjects.get(classSubject) || 0;
+          reviewedSubjects[classSubject] = curVal + course.reviewCount;
+        }
+      }));
 
-    // Creates a map of subjects (key) and total number of reviews (value)
-    const subjectsMap = new Map(Object.entries(reviewedSubjects).filter((x): x is [string, number] => typeof x[1] === "number"));
-    let subjectsAndReviewCountArray = Array.from(subjectsMap);
-    // Sorts array by number of reviews each topic has
-    subjectsAndReviewCountArray = subjectsAndReviewCountArray.sort((a, b) => (a[1] < b[1] ? 1 : a[1] > b[1] ? -1 : 0));
+      // Creates a map of subjects (key) and total number of reviews (value)
+      const subjectsMap = new Map(Object.entries(reviewedSubjects).filter((x): x is [string, number] => typeof x[1] === "number"));
+      let subjectsAndReviewCountArray = Array.from(subjectsMap);
+      // Sorts array by number of reviews each topic has
+      subjectsAndReviewCountArray = subjectsAndReviewCountArray.sort((a, b) => (a[1] < b[1] ? 1 : a[1] > b[1] ? -1 : 0));
 
-    // Returns the top 15 most reviewed classes
-    return subjectsAndReviewCountArray.slice(0, 15);
+      // Returns the top 15 most reviewed classes
+      return subjectsAndReviewCountArray.slice(0, 15);
+    } catch (error) {
+      // eslint-disable-next-line no-console
+      console.log("Error: at 'topSubjects' method");
+      // eslint-disable-next-line no-console
+      console.log(error);
+      return null;
+    }
   },
 
   // returns an array of objects in the form {_id: cs, total: 276}
   // represnting how many classes each dept (cs, info, coml etc...) offers
   async howManyEachClass(token: string) {
-    const userIsAdmin = await Meteor.call("tokenIsAdmin", token);
-    if (userIsAdmin) {
-      const pipeline = [
-        {
-          $group: {
-            _id: '$classSub',
-            total: {
-              $sum: 1,
+    try {
+      const userIsAdmin = await Meteor.call("tokenIsAdmin", token);
+      if (userIsAdmin) {
+        const pipeline = [
+          {
+            $group: {
+              _id: '$classSub',
+              total: {
+                $sum: 1,
+              },
             },
           },
-        },
-      ];
-      return await Classes.aggregate(pipeline, () => {});
+        ];
+        return await Classes.aggregate(pipeline, () => { });
+      }
+      return null;
+    } catch (error) {
+      // eslint-disable-next-line no-console
+      console.log("Error: at 'howManyEachClass' method");
+      // eslint-disable-next-line no-console
+      console.log(error);
+      return null;
     }
   },
 
   // returns an array of objs in the form {_id: cs 2112, total: 227}
   async howManyReviewsEachClass(token: string) {
-    const userIsAdmin = await Meteor.call('tokenIsAdmin', token);
-    if (userIsAdmin) {
-      const pipeline = [
-        {
-          $group: {
-            _id: '$class',
-            total: {
-              $sum: 1,
+    try {
+      const userIsAdmin = await Meteor.call('tokenIsAdmin', token);
+      if (userIsAdmin) {
+        const pipeline = [
+          {
+            $group: {
+              _id: '$class',
+              total: {
+                $sum: 1,
+              },
             },
           },
-        },
-      ];
-
-      const results = await Reviews.aggregate<{ _id: string; total: number }>(pipeline, () => {});
-
-      results.map(async (data) => {
-        const subNum = (await Classes.find({ _id: data._id }, { classSub: 1, classNum: 1 }).exec())[0];
-        const id = `${subNum.classSub} ${subNum.classNum}`;
-        return { _id: id, total: data.total };
-      });
-      return results;
+        ];
+        const results = await Reviews.aggregate<{ _id: string; total: number }>(pipeline, () => { });
+        results.map(async (data) => {
+          const subNum = (await Classes.find({ _id: data._id }, { classSub: 1, classNum: 1 }).exec())[0];
+          const id = `${subNum.classSub} ${subNum.classNum}`;
+          return { _id: id, total: data.total };
+        });
+        return results;
+      }
+      return null;
+    } catch (error) {
+      // eslint-disable-next-line no-console
+      console.log("Error: at 'howManyReviewsEachClass' method");
+      // eslint-disable-next-line no-console
+      console.log(error);
+      return null;
     }
   },
 
   // returns a count of the total reviews in the db
   async totalReviews(token: string) {
-    const userIsAdmin = await Meteor.call('tokenIsAdmin', token);
-    if (userIsAdmin) {
-      return Reviews.find({}).count();
+    try {
+      const userIsAdmin = await Meteor.call('tokenIsAdmin', token);
+      if (userIsAdmin) {
+        return Reviews.find({}).count();
+      }
+      return -1;
+    } catch (error) {
+      // eslint-disable-next-line no-console
+      console.log("Error: at 'totalReviews' method");
+      // eslint-disable-next-line no-console
+      console.log(error);
+      return -2;
     }
-    return -1;
   },
 
   // Returns an array in the form {cs: [{date1:totalNum}, {date2: totalNum}, ...],
   // math: [{date1:total}, {date2: total}, ...], ... } for the top 15 majors where
   // totalNum is the totalNum of reviews for classes in that major at date date1, date2 etc...
   async getReviewsOverTimeTop15(token: string, step, range) {
-    const userIsAdmin = await Meteor.call<boolean>('tokenIsAdmin', token);
-    if (userIsAdmin) {
-      const top15 = await Meteor.call<[string, number][]>('topSubjects');
-      // contains cs, math, gov etc...
-      const retArr = [];
-      await Promise.all(top15.map(async (classs) => {
-        const [subject] = await Subjects.find({
-          subFull: classs[0],
-        }, {
-          subShort: 1,
-        }).exec(); // EX: computer science--> cs
-
-        const subshort = subject.subShort;
-        retArr.push(subshort);
-      }));
-
-      const arrHM = [] as any[]; // [ {"cs": {date1: totalNum}, math: {date1, totalNum} },
-      // {"cs": {date2: totalNum}, math: {date2, totalNum} } ]
-
-      for (let i = 0; i < range * 30; i += step) {
-        // "data": -->this{"2017-01-01": 3, "2017-01-02": 4, ...}
-        // run on reviews. gets all classes and num of reviewa for each class, in x day
-        const pipeline = [{
-          $match: {
-            date: {
-              $lte: new Date(new Date().setDate(new Date().getDate() - i)),
-            },
-          },
-        },
-        {
-          $group: {
-            _id: '$class',
-            total: {
-              $sum: 1,
-            },
-          },
-        },
-        ];
-        const hashMap: any = {}; // Object {"cs": {date1: totalNum, date2: totalNum, ...}, math: {date1, totalNum} }
-
-        const results = await Reviews.aggregate<{ _id: string; total: number }>(pipeline, () => {});
-        await Promise.all(results.map(async (data) => { // { "_id" : "KyeJxLouwDvgY8iEu", "total" : 1 } //all in same date
-          const results = await Classes.find({
-            _id: data._id,
+    try {
+      const userIsAdmin = await Meteor.call<boolean>('tokenIsAdmin', token);
+      if (userIsAdmin) {
+        const top15 = await Meteor.call<[string, number][]>('topSubjects');
+        // contains cs, math, gov etc...
+        const retArr = [];
+        await Promise.all(top15.map(async (classs) => {
+          const [subject] = await Subjects.find({
+            subFull: classs[0],
           }, {
-            classSub: 1,
-          }).exec();
+            subShort: 1,
+          }).exec(); // EX: computer science--> cs
+          const subshort = subject.subShort;
+          retArr.push(subshort);
+        }));
+        const arrHM = [] as any[]; // [ {"cs": {date1: totalNum}, math: {date1, totalNum} },
+        // {"cs": {date2: totalNum}, math: {date2, totalNum} } ]
+        for (let i = 0; i < range * 30; i += step) {
+          // "data": -->this{"2017-01-01": 3, "2017-01-02": 4, ...}
+          // run on reviews. gets all classes and num of reviewa for each class, in x day
+          const pipeline = [{
+            $match: {
+              date: {
+                $lte: new Date(new Date().setDate(new Date().getDate() - i)),
+              },
+            },
+          },
+          {
+            $group: {
+              _id: '$class',
+              total: {
+                $sum: 1,
+              },
+            },
+          },
+          ];
+          const hashMap: any = {}; // Object {"cs": {date1: totalNum, date2: totalNum, ...}, math: {date1, totalNum} }
+          const results = await Reviews.aggregate<{ _id: string; total: number }>(pipeline, () => { });
+          await Promise.all(results.map(async (data) => { // { "_id" : "KyeJxLouwDvgY8iEu", "total" : 1 } //all in same date
+            const results = await Classes.find({
+              _id: data._id,
+            }, {
+              classSub: 1,
+            }).exec();
 
-          const sub = results[0]; // finds the class corresponding to "KyeJxLouwDvgY8iEu" ex: cs 2112
-          // date of this review minus the hrs mins sec
-          const timeStringYMD = new Date(new Date().setDate(new Date().getDate() - i)).toISOString().split('T')[0];
-          if (retArr.includes(sub.classSub)) { // if thos review is one of the top 15 we want.
-            if (hashMap[sub.classSub] == null) {
-              // if not in hm then add
-              hashMap[sub.classSub] = {
+            const sub = results[0]; // finds the class corresponding to "KyeJxLouwDvgY8iEu" ex: cs 2112
+            // date of this review minus the hrs mins sec
+            const timeStringYMD = new Date(new Date().setDate(new Date().getDate() - i)).toISOString().split('T')[0];
+            if (retArr.includes(sub.classSub)) { // if thos review is one of the top 15 we want.
+              if (hashMap[sub.classSub] == null) {
+                // if not in hm then add
+                hashMap[sub.classSub] = {
+                  [timeStringYMD]: data.total,
+                };
+              } else {
+                // increment totalnum
+                hashMap[sub.classSub] = {
+                  [timeStringYMD]: hashMap[sub.classSub][timeStringYMD] + data.total,
+                };
+              }
+            }
+            if (hashMap.total == null) {
+              hashMap.total = {
                 [timeStringYMD]: data.total,
               };
             } else {
-              // increment totalnum
-              hashMap[sub.classSub] = {
-                [timeStringYMD]: hashMap[sub.classSub][timeStringYMD] + data.total,
+              hashMap.total = {
+                [timeStringYMD]: hashMap.total[timeStringYMD] + data.total,
               };
             }
-          }
-          if (hashMap.total == null) {
-            hashMap.total = {
-              [timeStringYMD]: data.total,
-            };
-          } else {
-            hashMap.total = {
-              [timeStringYMD]: hashMap.total[timeStringYMD] + data.total,
-            };
-          }
-        }));
-        arrHM.push(hashMap);
+          }));
+          arrHM.push(hashMap);
+        }
+
+        const hm2 = {}; // {cs: [{date1:totalNum}, {date2: totalNum}, ...], math: [{date1:total}, {date2: total}, ...], ... }
+
+        // enrty:{"cs": {date1: totalNum}, math: {date1, totalNum} }
+        if (arrHM.length > 0) {
+          const entry = arrHM[0];
+          const keys = Object.keys(entry);
+
+          // "cs"
+          keys.forEach((key) => {
+            const t = arrHM.map((a) => a[key]); // for a key EX:"cs": [{date1:totalNum},{date2:totalNum}]
+            hm2[key] = t;
+          });
+        }
+
+        return hm2;
       }
-
-      const hm2 = {}; // {cs: [{date1:totalNum}, {date2: totalNum}, ...], math: [{date1:total}, {date2: total}, ...], ... }
-
-      // enrty:{"cs": {date1: totalNum}, math: {date1, totalNum} }
-      if (arrHM.length > 0) {
-        const entry = arrHM[0];
-        const keys = Object.keys(entry);
-
-        // "cs"
-        keys.forEach((key) => {
-          const t = arrHM.map((a) => a[key]); // for a key EX:"cs": [{date1:totalNum},{date2:totalNum}]
-          hm2[key] = t;
-        });
-      }
-
-      return hm2;
+    } catch (error) {
+      // eslint-disable-next-line no-console
+      console.log("Error: at 'getReviewsOverTimeTop15' method");
+      // eslint-disable-next-line no-console
+      console.log(error);
+      return null;
     }
   },
 
@@ -842,7 +1060,7 @@ Meteor.methods({
    */
   async getVerificationTicket(token?: string) {
     try {
-      if (token == null) {
+      if (token === null) {
         console.log("Token was undefined in getVerificationTicket");
         return null; // Token was undefined
       }
@@ -853,9 +1071,11 @@ Meteor.methods({
         // [CLIENT_ID_1, CLIENT_ID_2, CLIENT_ID_3]
       });
       return ticket.getPayload();
-    } catch (e) {
-      console.log("Error: at getVerificationTicket");
-      console.log(e);
+    } catch (error) {
+      // eslint-disable-next-line no-console
+      console.log("Error: at 'getVerificationTicket' method");
+      // eslint-disable-next-line no-console
+      console.log(error);
       return null;
     }
   },

--- a/server/server.ts
+++ b/server/server.ts
@@ -27,7 +27,7 @@ function setup() {
 const uri = process.env.MONGODB_URL ? process.env.MONGODB_URL : "this will error";
 let localMongoServer;
 
-mongoose.connect(uri, { useNewUrlParser: true, useUnifiedTopology: true }).then(() => setup()).catch(async err => {
+mongoose.connect(uri, { useNewUrlParser: true, useUnifiedTopology: true }).then(() => setup()).catch(async (err) => {
   console.log("No DB connection defined!");
 
   // If the environment variable is set, create a simple local db to work with
@@ -40,10 +40,10 @@ mongoose.connect(uri, { useNewUrlParser: true, useUnifiedTopology: true }).then(
     const mongoUri = await localMongoServer.getUri();
     await mongoose.connect(mongoUri, { useNewUrlParser: true, useUnifiedTopology: true });
 
-    await fetchAddCourses("https://classes.cornell.edu/api/2.0/", "FA19").catch(err => console.log(err));
+    await fetchAddCourses("https://classes.cornell.edu/api/2.0/", "FA19").catch((err) => console.log(err));
 
-    await mongoose.connection.collections["classes"].createIndex({ "classFull": "text" });
-    await mongoose.connection.collections["subjects"].createIndex({ "subShort": "text" });
+    await mongoose.connection.collections.classes.createIndex({ classFull: "text" });
+    await mongoose.connection.collections.subjects.createIndex({ subShort: "text" });
     setup();
   } else {
     process.exit(1);

--- a/server/server.ts
+++ b/server/server.ts
@@ -45,7 +45,7 @@ mongoose.connect(uri, { useNewUrlParser: true, useUnifiedTopology: true }).then(
     await mongoose.connection.collections.classes.createIndex({ classFull: "text" });
     await mongoose.connection.collections.subjects.createIndex({ subShort: "text" });
     await mongoose.connection.collections.professors.createIndex({ fullName: "text" });
-    
+
     setup();
   } else {
     process.exit(1);

--- a/server/server.ts
+++ b/server/server.ts
@@ -44,6 +44,8 @@ mongoose.connect(uri, { useNewUrlParser: true, useUnifiedTopology: true }).then(
 
     await mongoose.connection.collections.classes.createIndex({ classFull: "text" });
     await mongoose.connection.collections.subjects.createIndex({ subShort: "text" });
+    await mongoose.connection.collections.professors.createIndex({ fullName: "text" });
+    
     setup();
   } else {
     process.exit(1);

--- a/server/server.ts
+++ b/server/server.ts
@@ -1,10 +1,12 @@
 import path from "path";
 import express from "express";
 import mongoose from "mongoose";
-
+import { MongoMemoryServer } from "mongodb-memory-server";
 import cors from "cors";
 import dotenv from "dotenv";
 import { Meteor } from "./shim";
+import { fetchAddCourses } from "./dbInit";
+import { Classes } from "./dbDefs";
 
 dotenv.config();
 const app = express();
@@ -22,4 +24,28 @@ function setup() {
   });
 }
 
-mongoose.connect(process.env.MONGODB_URL, { useNewUrlParser: true, useUnifiedTopology: true }).then(() => setup());
+const uri = process.env.MONGODB_URL ? process.env.MONGODB_URL : "this will error";
+let localMongoServer;
+
+mongoose.connect(uri, { useNewUrlParser: true, useUnifiedTopology: true }).then(() => setup()).catch(async err => {
+  console.log("No DB connection defined!");
+
+  // If the environment variable is set, create a simple local db to work with
+  // This could be expanded in the future with default mock admin accounts, etc.
+  // For now, it fetches Fall 2019 classes for you to view
+  // This is useful if you need a local db without any hassle, and don't want to risk damage to the staging db
+  if (process.env.ALLOW_LOCAL === "1") {
+    console.log("Falling back to local db!");
+    localMongoServer = new MongoMemoryServer();
+    const mongoUri = await localMongoServer.getUri();
+    await mongoose.connect(mongoUri, { useNewUrlParser: true, useUnifiedTopology: true });
+
+    await fetchAddCourses("https://classes.cornell.edu/api/2.0/", "FA19").catch(err => console.log(err));
+
+    await mongoose.connection.collections["classes"].createIndex({ "classFull": "text" });
+    await mongoose.connection.collections["subjects"].createIndex({ "subShort": "text" });
+    setup();
+  } else {
+    process.exit(1);
+  }
+});

--- a/server/shim.ts
+++ b/server/shim.ts
@@ -12,9 +12,17 @@ export class MeteorShim {
   private _app: express.Application | null = null;
 
   async call<T = unknown>(key: string, ...args: any[]): Promise<T> {
-    const method = this._methods.get(key);
-    if (!method) throw new Error("Unknown method called...");
-    return await method(...args);
+    try {
+      const method = this._methods.get(key);
+      if (!method) throw new Error("Unknown method called...");
+      return await method(...args);
+    } catch (error) {
+      // eslint-disable-next-line no-console
+      console.log("Error: at 'call' method in shim.ts");
+      // eslint-disable-next-line no-console
+      console.log(error);
+      return null;
+    }
   }
 
   registerApp(app: express.Application) { this._app = app; }


### PR DESCRIPTION
### Summary <!-- Required -->

Goal: After #145 , we don't know if our scraper works. This is an attempt to write a tested scraping implementation. The old one was also not easy to understand.

It's like #173, except our goal is to make to make a correcter scraping implementation rather than a faster scraping implementation. Fun Fact: Compared to the 15 mins it historically took, this is actually doing pretty well!

Frontend integration will be split out into a seperate PR.

### Test Plan <!-- Required -->

All tests are in the file dbInit.test.ts. We create a mock endpoint, and then scrape from it. The scraper is split up into various utility functions, which are seperatly tested.

It was also tested on a clean db. You can also do so by running. This will automatically do everything for you. No need to fumble about with mongod or anything.
```bash
ALLOW_LOCAL=1 yarn workspace server start
```

### Notes

Added the ALLOW_LOCAL program option. Passing ALLOW_LOCAL=1 and no mongodb uri to connect to automatically now starts a blank in-memory mongo server, which is the populated using FA19 data. This process takes ~1-2 mins on my machine. This is useful to test features involving the db, if you are worried that this might cause issues with the staging db. In this case, it was used to manually verify that scraping worked. NOTE: there are still some errors, because the professors db is not properly initialized. TODO: Fix this.