### PR TITLE
Blank helpful

### DIFF
--- a/client/src/ui/Review.jsx
+++ b/client/src/ui/Review.jsx
@@ -191,7 +191,7 @@ export default class Review extends Component {
                       alt={this.state.liked ? "Liked" : "Not Liked Yet"}
                     />
                     <p className="upvote-text">Helpful
-                        ({this.state.numLikes})</p>
+                        ({this.state.numLikes ? this.state.numLikes : 0})</p>
                   </button>
                 }
               </div>

--- a/client/src/ui/Review.jsx
+++ b/client/src/ui/Review.jsx
@@ -69,10 +69,18 @@ export default class Review extends Component {
     if (this.state.liked === false) {
       return Meteor.call('incrementLike', review._id, (error, result) => {
         if (!error && result === 1) {
-          this.setState({
-            liked: true,
-            numLikes: this.state.numLikes + 1 //updates the likes on the PreviewCard review in realtime
-          })
+            if (!this.state.numLikes) {
+              this.setState({
+                liked: true,
+                numLikes: 1 
+              })
+          }
+          else {
+            this.setState({
+              liked: true,
+              numLikes: this.state.numLikes + 1 //updates the likes on the PreviewCard review in realtime
+            })
+          }
           console.log(this.state.liked);
           console.log("Likes: " + review.likes);
         } else {


### PR DESCRIPTION
### Summary <!-- Required -->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Itemize bug fixes, new features, and other changes -->
<!-- Feel free to break this into sub-sections, i.e. features, fixes, etc. -->
<!-- Some examples are shown below. -->

This fixes the issue of empty helpful quantities on reviews.

### Test Plan <!-- Required -->

Identified reviews locally with empty Helpful numbers. Then, I implemented my changes and verified that:
1. They now showed 0
2. Clicking over and over would update the number properly
3. The correct number was there after a refresh

Will test again on dev site using same criteria

### Notes <!-- Optional -->



### Breaking Changes  <!-- Optional -->


