### PR TITLE
Added mongodb-binaries to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ dist
 build
 mongo_backups/*
 !mongo_backups/.gitkeep
+mongodb-binaries/
 .git
 .vscode
 .env


### PR DESCRIPTION
This pull request simply adds mongodb-binaries to .gitignore. I noticed that after running jest tests a folder called `mongodb-binaries` was created and tracked by git. I imagine we don't want these to be pushed to the repo.

