### PR TITLE
Reset gauge percentage when value is NaN

### DIFF
--- a/client/src/ui/Gauge.tsx
+++ b/client/src/ui/Gauge.tsx
@@ -60,7 +60,7 @@ export default class Gauge extends Component<Props,State>{
         this.setState({percentage: percentage, color: color, rating: this.props.rating.toFixed(1)});
       }
       else{
-        this.setState({rating: "-"});
+        this.setState({rating: "-", percentage:0.0});
       }
     }
 


### PR DESCRIPTION
### Summary <!-- Required -->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Itemize bug fixes, new features, and other changes -->
<!-- Feel free to break this into sub-sections, i.e. features, fixes, etc. -->
<!-- Some examples are shown below. -->

This pull request fixes issue #203. It simply resets the percentage of the gauge to 0 when there is no metric available, where as the percentage would stay the same before.

### Test Plan <!-- Required -->

<!-- Provide screenshots or point out the additional unit tests -->

Tested by clicking through classes and verifying values and percentage filled was changed appropriately. I also checked that the gauges still loaded properly on individual class pages.
Clicking on class with reviews:
![image](https://user-images.githubusercontent.com/40501830/96029685-01b4b480-0e29-11eb-8d18-83c3fbb9a27d.png)

And then clicking on one with no reviews right after:
![image](https://user-images.githubusercontent.com/40501830/96029760-185b0b80-0e29-11eb-8d5b-9529a6f37cd6.png)


