### PR TITLE
Remove virtual weight

### DIFF
--- a/client/src/ui/CourseCard.tsx
+++ b/client/src/ui/CourseCard.tsx
@@ -3,7 +3,7 @@ import { Meteor } from "../meteor-shim";
 import Form from './Form.jsx';
 import './css/CourseCard.css';
 import { Class, Review } from 'common';
-import { lastOfferedSems, getGaugeValues } from 'common/CourseCard';
+import { lastOfferedSems } from 'common/CourseCard';
 
 type Props = {
   course: Class;
@@ -54,19 +54,19 @@ export class CourseCard extends Component<Props, State> {
   // Whenever the incoming props change (i.e, the database of reviews for a class
   // is updated) trigger a re-render by updating the gauge values in the local state.
   componentWillReceiveProps(nextProps: Props) {
-    this.updateState(nextProps.course, nextProps.reviews);
+    this.updateState(nextProps.course);
   }
 
   // Recalculate gauge values and other metrics to update the local state
-  updateState(selectedClass: any, allReviews: any) {
+  updateState(selectedClass: any) {
     if (selectedClass !== null && selectedClass !== undefined) {
       // gather data on the reviews and set mandatory flags.
-      if (allReviews.length !== 0) {
-        // set the new state to the collected values. Calls getGaugeValues function in CourseCard.js
-        this.setState(getGaugeValues(allReviews));
-      } else {
-        this.setState(this.defaultGaugeState); //default gauge values
-      }
+        // set the new state to metrics stored in DB for this class
+        this.setState({
+          rating: selectedClass.classRating,
+          workload: selectedClass.classWorkload,
+          diff: selectedClass.classDifficulty
+        });
     }
     else {
       this.setState(this.defaultGaugeState); //default gauge values

--- a/common/CourseCard.js
+++ b/common/CourseCard.js
@@ -60,111 +60,54 @@ function getCrossListOR(course) {
 // collect aggregate information from allReviews, the list of all reviews
 // submitted for this class. Return values for the average difficulty, quality,
 // and madatory/not mandatory status.
-function getGaugeValues(allReviews) {
-  // how much should we factor in virtual reviews? Weighted, 0-1, where 1 is as much a regular reviews
-  const virtualWeightFactor = 0;
+function getMetricValues(allReviews) {
 
   const newState = {};
   // create summation variables for reviews
-  let sumRatingNormal = 0;
-  let sumDiffNormal = 0;
-  let sumWorkNormal = 0;
-
-  let sumRatingVirtual = 0;
-  let sumDiffVirtual = 0;
-  let sumWorkVirtual = 0;
+  let sumRating = 0;
+  let sumDiff = 0;
+  let sumWork = 0;
 
   // create size counting variables
-  let countRatingNormal = 0;
-  let countDiffNormal = 0;
-  let countWorkNormal = 0;
-
-  let countRatingVirtual = 0;
-  let countDiffVirtual = 0;
-  let countWorkVirtual = 0;
+  let countRating = 0;
+  let countDiff = 0;
+  let countWork = 0;
 
   allReviews.forEach((review) => {
-    if (review) {
-      if (review.virtual) {
-        sumDiffVirtual += Number(review.difficulty);
-        countDiffVirtual++;
+    sumDiff += Number(review.difficulty);
+    countDiff++;
 
-        if (review.rating) {
-          countRatingVirtual++;
-          sumRatingVirtual += Number(review.rating);
-        } else if (review.quality) {
-          countRatingVirtual++;
-          sumRatingVirtual += Number(review.quality);
-        }
-        if (review.workload) {
-          countWorkVirtual++;
-          sumWorkVirtual += Number(review.workload);
-        }
-      } else {
-        sumDiffNormal += Number(review.difficulty);
-        countDiffNormal++;
+    if (review.rating) {
+      countRating++;
+      sumRating += Number(review.rating);
+    } else if (review.quality) {
+      countRating++;
+      sumRating += Number(review.quality);
+    }
 
-        if (review.rating) {
-          countRatingNormal++;
-          sumRatingNormal += Number(review.rating);
-        } else if (review.quality) {
-          countRatingNormal++;
-          sumRatingNormal += Number(review.quality);
-        }
-
-        if (review.workload) {
-          countWorkNormal++;
-          sumWorkNormal += Number(review.workload);
-        }
-      }
+    if (review.workload) {
+      countWork++;
+      sumWork += Number(review.workload);
     }
   });
 
-  // a division function for which divide by 0 is defined to return 0
-  // allows us to optimize the following code
-  const safe_divide = (a, b) => (b == 0 ? 0 : a / b);
 
-  // we know that if these are 0, then there must not be reviews of that type
-  // why? because the minimum rating that anyone can give is 1!
-  const ratingRatioNormal = safe_divide(sumRatingNormal, countRatingNormal);
-  const ratingRatioVirtual = safe_divide(sumRatingVirtual, countRatingVirtual);
-
-  if (ratingRatioNormal == 0 && ratingRatioVirtual == 0) {
-    newState.rating = "-";
-  } else if (ratingRatioNormal == 0) {
-    newState.rating = ratingRatioVirtual.toFixed(1);
-  } else if (ratingRatioVirtual == 0) {
-    newState.rating = ratingRatioNormal.toFixed(1);
+  if(countRating > 0) {
+    newState.rating = sumRating / countRating;
   } else {
-    newState.rating = ((ratingRatioNormal + virtualWeightFactor * ratingRatioVirtual) / (1 + virtualWeightFactor)).toFixed(1);
+    newState.rating = "-";
   }
 
-  // these behave the same as their counterparts for ratings
-  const diffRatioNormal = safe_divide(sumDiffNormal, countDiffNormal);
-  const diffRatioVirtual = safe_divide(sumDiffVirtual, countDiffVirtual);
+  if(countWork > 0) {
+    newState.workload = sumWork / countWork;
+  } else {
+    newState.workload = "-";
+  }
 
-  if (diffRatioNormal == 0 && diffRatioVirtual == 0) {
+  if(countDiff > 0) {
+    newState.diff = sumDiff / countDiff;
+  } else {
     newState.diff = "-";
-  } else if (diffRatioNormal == 0) {
-    newState.diff = diffRatioVirtual.toFixed(1);
-  } else if (diffRatioVirtual == 0) {
-    newState.diff = diffRatioNormal.toFixed(1);
-  } else {
-    newState.diff = ((diffRatioNormal + virtualWeightFactor * diffRatioVirtual) / (1 + virtualWeightFactor)).toFixed(1);
-  }
-
-  // these behave the same as their counterparts for ratings
-  const workloadRatioNormal = safe_divide(sumWorkNormal, countWorkNormal);
-  const workloadRatioVirtual = safe_divide(sumWorkVirtual, countWorkVirtual);
-
-  if (workloadRatioNormal == 0 && workloadRatioVirtual == 0) {
-    newState.rating = "-";
-  } else if (workloadRatioNormal == 0) {
-    newState.workload = workloadRatioVirtual.toFixed(1);
-  } else if (workloadRatioVirtual == 0) {
-    newState.workload = workloadRatioNormal.toFixed(1);
-  } else {
-    newState.workload = ((workloadRatioNormal + virtualWeightFactor * workloadRatioVirtual) / (1 + virtualWeightFactor)).toFixed(1);
   }
 
   // Set gauge color for rating
@@ -198,5 +141,5 @@ function getGaugeValues(allReviews) {
 }
 
 module.exports = {
-  lastOfferedSems, semAbbriviationToWord, lastSem, getCrossListOR, getGaugeValues,
+  lastOfferedSems, semAbbriviationToWord, lastSem, getCrossListOR, getMetricValues,
 };

--- a/common/CourseCard.js
+++ b/common/CourseCard.js
@@ -61,7 +61,6 @@ function getCrossListOR(course) {
 // submitted for this class. Return values for the average difficulty, quality,
 // and madatory/not mandatory status.
 function getMetricValues(allReviews) {
-
   const newState = {};
   // create summation variables for reviews
   let sumRating = 0;
@@ -92,19 +91,19 @@ function getMetricValues(allReviews) {
   });
 
 
-  if(countRating > 0) {
+  if (countRating > 0) {
     newState.rating = sumRating / countRating;
   } else {
     newState.rating = "-";
   }
 
-  if(countWork > 0) {
+  if (countWork > 0) {
     newState.workload = sumWork / countWork;
   } else {
     newState.workload = "-";
   }
 
-  if(countDiff > 0) {
+  if (countDiff > 0) {
     newState.diff = sumDiff / countDiff;
   } else {
     newState.diff = "-";

--- a/server/methods.ts
+++ b/server/methods.ts
@@ -1,4 +1,4 @@
-import { getGaugeValues, getCrossListOR } from 'common/CourseCard';
+import { getMetricValues, getCrossListOR } from 'common/CourseCard';
 import { OAuth2Client } from 'google-auth-library';
 import { TokenPayload } from 'google-auth-library/build/src/auth/loginticket';
 import shortid from 'shortid';
@@ -291,12 +291,12 @@ Meteor.methods({
         if (course) {
           const crossListOR = getCrossListOR(course);
           const reviews = await Reviews.find({ visible: 1, reported: 0, $or: crossListOR }, {}, { sort: { date: -1 }, limit: 700 }).exec();
-          const state = getGaugeValues(reviews);
+          const state = getMetricValues(reviews);
 
           await Classes.updateOne({ _id: courseId },
             {
               $set: {
-                // If no data is available, getGaugeValues returns "-" for metric
+                // If no data is available, getMetricValues returns "-" for metric
                 classDifficulty: (state.diff !== "-" && !isNaN(state.diff) ? Number(state.diff) : null),
                 classRating: (state.rating !== "-" && !isNaN(state.rating) ? Number(state.rating) : null),
                 classWorkload: (state.workload !== "-" && !isNaN(state.workload) ? Number(state.workload) : null),


### PR DESCRIPTION
### Summary <!-- Required -->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Itemize bug fixes, new features, and other changes -->
<!-- Feel free to break this into sub-sections, i.e. features, fixes, etc. -->
<!-- Some examples are shown below. -->

This pull request removes weighting of COVID affected/virtual reviews differently than other reviews. It also refactors the course card to get class metric values based on the values in the DB rather than recalculating them.

### Test Plan <!-- Required -->

Tested by locally creating and then reporting/removing reviews for classes with reviews and without reviews to see if metrics changed as expected on the front end at each step.

### Notes <!-- Optional -->

common/CourseCard.js should probably be split up; I think it no longer contains functions used by both the back end and the front end.

### Breaking Changes  <!-- Optional -->

Changing how the front end gets the values for gauges has potential to cause errors but looks good from my testing.
