### PR TITLE
Force HTTPS connection

### DIFF
--- a/server/package.json
+++ b/server/package.json
@@ -32,6 +32,7 @@
     "dotenv": "^8.2.0",
     "express": "^4.17.1",
     "google-auth-library": "^6.0.0",
+    "heroku-ssl-redirect": "^0.1.1",
     "mongodb": "^3.5.5",
     "mongodb-memory-server": "^6.5.2",
     "mongoose": "^5.9.6",

--- a/server/server.ts
+++ b/server/server.ts
@@ -1,5 +1,6 @@
 import path from "path";
 import express from "express";
+import sslRedirect from 'heroku-ssl-redirect';
 import mongoose from "mongoose";
 import { MongoMemoryServer } from "mongodb-memory-server";
 import cors from "cors";
@@ -10,6 +11,10 @@ import { Classes, Students } from "./dbDefs";
 
 dotenv.config();
 const app = express();
+app.use(sslRedirect([
+  'development',
+  'production',
+]));
 app.use(cors());
 app.use(express.static(path.join(__dirname, "../../client/build")));
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -5786,6 +5786,11 @@ he@^1.2.0:
   resolved "https://registry.yarnpkg.com/he/-/he-1.2.0.tgz#84ae65fa7eafb165fddb61566ae14baf05664f0f"
   integrity sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==
 
+heroku-ssl-redirect@^0.1.1:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/heroku-ssl-redirect/-/heroku-ssl-redirect-0.1.1.tgz#c55d60c0ec4473358ead66c75e8c7e99d9e8a689"
+  integrity sha512-kL/DvLR2J53iB3TXasQlo5JwF/j2L2zkala6Ddk9o6JwIPeDvbTGT9Aty8WElxcF389ObICCeyf2m7RKpCg5Bg==
+
 hex-color-regex@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/hex-color-regex/-/hex-color-regex-1.1.0.tgz#4c06fccb4602fe2602b3c93df82d7e7dbf1a8a8e"


### PR DESCRIPTION
### Summary <!-- Required -->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Itemize bug fixes, new features, and other changes -->
<!-- Feel free to break this into sub-sections, i.e. features, fixes, etc. -->
<!-- Some examples are shown below. -->

This PR fixes the issue where some users land on the `http://` version of CUReviews.  This leads to problems when submitting a review.

### Test Plan <!-- Required -->

<!-- Provide screenshots or point out the additional unit tests -->

Plan to test on a PR deployment created by Heroku

### Notes <!-- Optional -->

- This _does not_ force HTTPS on localhost, do not expect this behavior
- Credz: https://medium.com/@seunghunsunmoonlee/how-to-enforce-https-redirect-http-to-https-on-heroku-deployed-apps-a87a653ba61e
