### PR TITLE
Express Endpoint for viewing Reviews

### DIFF
--- a/client/src/ui/CourseReviews.tsx
+++ b/client/src/ui/CourseReviews.tsx
@@ -23,22 +23,25 @@ type State = { comparator: 'helpful'; reviews: any };
 export class CourseReviews extends Component<Props, State> {
   constructor(props: Props) {
     super(props);
-    this.state={comparator:"helpful", reviews:[]};
+    this.state = { comparator: "helpful", reviews: [] };
   }
 
-  componentDidMount(){
-    Meteor.call("getReviewsByCourseId", this.props.courseId, (_: any, reviews: any)=>{
-      this.setState({reviews:this.renderReviews(reviews)});
+  componentDidMount() {
+    console.log("course id in courseReviews co ", this.props.courseId);
+    Meteor.call("getReviewsByCourseId", this.props.courseId, (_: any, reviews: any) => {
+      console.log(reviews);
+
+      this.setState({ reviews: this.renderReviews(reviews) });
       this.sort(this.state.comparator);
     });
   }
 
-  componentDidUpdate(prevProps: Props){
+  componentDidUpdate(prevProps: Props) {
     if (prevProps !== this.props)
-    Meteor.call("getReviewsByCourseId", this.props.courseId, (_: any, reviews: any)=>{
-      this.setState({reviews:this.renderReviews(reviews)});
-      this.sort(this.state.comparator);
-    });
+      Meteor.call("getReviewsByCourseId", this.props.courseId, (_: any, reviews: any) => {
+        this.setState({ reviews: this.renderReviews(reviews) });
+        this.sort(this.state.comparator);
+      });
   }
 
 
@@ -50,38 +53,38 @@ export class CourseReviews extends Component<Props, State> {
   }
 
   sort = (comp: 'helpful') => {
-    let reviews=this.state.reviews;
-    let data=[];
-    if(comp==="helpful") data= reviews.sort((a: any, b: any) => {
-      if( !b.props.info.likes) return -1;
-      if( !a.props.info.likes) return 1;
-    if( b.props.info && a.props.info){
-      if (a.props.info.likes > b.props.info.likes) {
-        return -1;
+    let reviews = this.state.reviews;
+    let data = [];
+    if (comp === "helpful") data = reviews.sort((a: any, b: any) => {
+      if (!b.props.info.likes) return -1;
+      if (!a.props.info.likes) return 1;
+      if (b.props.info && a.props.info) {
+        if (a.props.info.likes > b.props.info.likes) {
+          return -1;
+        }
+        if (a.props.info.likes < b.props.info.likes) {
+          return 1;
+        }
       }
-      if (a.props.info.likes < b.props.info.likes) {
-        return 1;
-      }
-    }
 
-    return 0;
-  })
-  else data= reviews.sort((a: any, b: any) => {
-    if( !b.props.info.date) return 1;
-    if( !a.props.info.date) return -1;
-    if (b.props.info && a.props.info){
-      console.log(a.props.info.date+" "+a.props.info.date);
-      if (a.props.info.date > b.props.info.date) {
-        return -1;
+      return 0;
+    })
+    else data = reviews.sort((a: any, b: any) => {
+      if (!b.props.info.date) return 1;
+      if (!a.props.info.date) return -1;
+      if (b.props.info && a.props.info) {
+        console.log(a.props.info.date + " " + a.props.info.date);
+        if (a.props.info.date > b.props.info.date) {
+          return -1;
+        }
+        if (a.props.info.date < b.props.info.date) {
+          return 1;
+        }
       }
-      if (a.props.info.date < b.props.info.date) {
-        return 1;
-      }
-    }
-    return 0;
-  });
+      return 0;
+    });
 
-  this.setState({reviews:data});
+    this.setState({ reviews: data });
   };
 
   // Report this review. Find the review in the local database and change
@@ -93,7 +96,7 @@ export class CourseReviews extends Component<Props, State> {
         while (idx < this.state.reviews.length && this.state.reviews[idx].key !== review._id) {
           idx++;
         }
-        this.setState({reviews: this.state.reviews.slice(0, idx).concat(this.state.reviews.slice(idx+1)) });
+        this.setState({ reviews: this.state.reviews.slice(0, idx).concat(this.state.reviews.slice(idx + 1)) });
         console.log("reported review #" + review._id);
       } else {
         console.log(error)
@@ -105,19 +108,19 @@ export class CourseReviews extends Component<Props, State> {
   renderReviews(reviews: readonly ReviewType[]) {
     const reviewCompList: any[] = [];
     if (this.props.courseId === "-1") {
-       reviews.forEach((review) => (
+      reviews.forEach((review) => (
         reviewCompList.push(<RecentReview key={review._id} info={review} reportHandler={this.reportReview} />)
       ));
     } else {
-       reviews.forEach((review) => (
-        reviewCompList.push(<Review key={review._id} info={review} reportHandler={this.reportReview} isPreview={false}/>)
+      reviews.forEach((review) => (
+        reviewCompList.push(<Review key={review._id} info={review} reportHandler={this.reportReview} isPreview={false} />)
       ));
       return reviewCompList;
     }
   }
 
   render() {
-    let title = "Past Reviews ("+this.state.reviews.length+")";
+    let title = "Past Reviews (" + this.state.reviews.length + ")";
     if (this.props.courseId === "-1") {
       title = "Recent Reviews";
     }
@@ -131,7 +134,7 @@ export class CourseReviews extends Component<Props, State> {
           <div className="coursereviews-sort-container">
             <div className="coursereviews-sort"> Sort By:
               <select onChange={this.handleSelect} className="coursereviews-sort-options">
-                <option  value="helpful">Most Helpful</option>
+                <option value="helpful">Most Helpful</option>
                 <option value="recent">Recent</option>
               </select>
             </div>

--- a/client/src/ui/CourseReviews.tsx
+++ b/client/src/ui/CourseReviews.tsx
@@ -23,25 +23,22 @@ type State = { comparator: 'helpful'; reviews: any };
 export class CourseReviews extends Component<Props, State> {
   constructor(props: Props) {
     super(props);
-    this.state = { comparator: "helpful", reviews: [] };
+    this.state={comparator:"helpful", reviews:[]};
   }
 
-  componentDidMount() {
-    console.log("course id in courseReviews co ", this.props.courseId);
-    Meteor.call("getReviewsByCourseId", this.props.courseId, (_: any, reviews: any) => {
-      console.log(reviews);
-
-      this.setState({ reviews: this.renderReviews(reviews) });
+  componentDidMount(){
+    Meteor.call("getReviewsByCourseId", this.props.courseId, (_: any, reviews: any)=>{
+      this.setState({reviews:this.renderReviews(reviews)});
       this.sort(this.state.comparator);
     });
   }
 
-  componentDidUpdate(prevProps: Props) {
+  componentDidUpdate(prevProps: Props){
     if (prevProps !== this.props)
-      Meteor.call("getReviewsByCourseId", this.props.courseId, (_: any, reviews: any) => {
-        this.setState({ reviews: this.renderReviews(reviews) });
-        this.sort(this.state.comparator);
-      });
+    Meteor.call("getReviewsByCourseId", this.props.courseId, (_: any, reviews: any)=>{
+      this.setState({reviews:this.renderReviews(reviews)});
+      this.sort(this.state.comparator);
+    });
   }
 
 
@@ -53,38 +50,38 @@ export class CourseReviews extends Component<Props, State> {
   }
 
   sort = (comp: 'helpful') => {
-    let reviews = this.state.reviews;
-    let data = [];
-    if (comp === "helpful") data = reviews.sort((a: any, b: any) => {
-      if (!b.props.info.likes) return -1;
-      if (!a.props.info.likes) return 1;
-      if (b.props.info && a.props.info) {
-        if (a.props.info.likes > b.props.info.likes) {
-          return -1;
-        }
-        if (a.props.info.likes < b.props.info.likes) {
-          return 1;
-        }
+    let reviews=this.state.reviews;
+    let data=[];
+    if(comp==="helpful") data= reviews.sort((a: any, b: any) => {
+      if( !b.props.info.likes) return -1;
+      if( !a.props.info.likes) return 1;
+    if( b.props.info && a.props.info){
+      if (a.props.info.likes > b.props.info.likes) {
+        return -1;
       }
-
-      return 0;
-    })
-    else data = reviews.sort((a: any, b: any) => {
-      if (!b.props.info.date) return 1;
-      if (!a.props.info.date) return -1;
-      if (b.props.info && a.props.info) {
-        console.log(a.props.info.date + " " + a.props.info.date);
-        if (a.props.info.date > b.props.info.date) {
-          return -1;
-        }
-        if (a.props.info.date < b.props.info.date) {
-          return 1;
-        }
+      if (a.props.info.likes < b.props.info.likes) {
+        return 1;
       }
-      return 0;
-    });
+    }
 
-    this.setState({ reviews: data });
+    return 0;
+  })
+  else data= reviews.sort((a: any, b: any) => {
+    if( !b.props.info.date) return 1;
+    if( !a.props.info.date) return -1;
+    if (b.props.info && a.props.info){
+      console.log(a.props.info.date+" "+a.props.info.date);
+      if (a.props.info.date > b.props.info.date) {
+        return -1;
+      }
+      if (a.props.info.date < b.props.info.date) {
+        return 1;
+      }
+    }
+    return 0;
+  });
+
+  this.setState({reviews:data});
   };
 
   // Report this review. Find the review in the local database and change
@@ -96,7 +93,7 @@ export class CourseReviews extends Component<Props, State> {
         while (idx < this.state.reviews.length && this.state.reviews[idx].key !== review._id) {
           idx++;
         }
-        this.setState({ reviews: this.state.reviews.slice(0, idx).concat(this.state.reviews.slice(idx + 1)) });
+        this.setState({reviews: this.state.reviews.slice(0, idx).concat(this.state.reviews.slice(idx+1)) });
         console.log("reported review #" + review._id);
       } else {
         console.log(error)
@@ -108,19 +105,19 @@ export class CourseReviews extends Component<Props, State> {
   renderReviews(reviews: readonly ReviewType[]) {
     const reviewCompList: any[] = [];
     if (this.props.courseId === "-1") {
-      reviews.forEach((review) => (
+       reviews.forEach((review) => (
         reviewCompList.push(<RecentReview key={review._id} info={review} reportHandler={this.reportReview} />)
       ));
     } else {
-      reviews.forEach((review) => (
-        reviewCompList.push(<Review key={review._id} info={review} reportHandler={this.reportReview} isPreview={false} />)
+       reviews.forEach((review) => (
+        reviewCompList.push(<Review key={review._id} info={review} reportHandler={this.reportReview} isPreview={false}/>)
       ));
       return reviewCompList;
     }
   }
 
   render() {
-    let title = "Past Reviews (" + this.state.reviews.length + ")";
+    let title = "Past Reviews ("+this.state.reviews.length+")";
     if (this.props.courseId === "-1") {
       title = "Recent Reviews";
     }
@@ -134,7 +131,7 @@ export class CourseReviews extends Component<Props, State> {
           <div className="coursereviews-sort-container">
             <div className="coursereviews-sort"> Sort By:
               <select onChange={this.handleSelect} className="coursereviews-sort-options">
-                <option value="helpful">Most Helpful</option>
+                <option  value="helpful">Most Helpful</option>
                 <option value="recent">Recent</option>
               </select>
             </div>

--- a/server/endpoints.ts
+++ b/server/endpoints.ts
@@ -1,7 +1,7 @@
 import express from "express";
 import { validationResult, ValidationChain } from "express-validator";
 import { getClassesByQuery } from "./endpoints/SearchBar";
-import { getReviewsByCourseId } from "./endpoints/Review";
+import { getReviewsByCourseId, getCourseById } from "./endpoints/Review";
 // A type which captures an endpoint, and the guard for that endpoint
 // INVARIANT: If an object passes the guard, it can be coerced into type T
 export interface Endpoint<T> {
@@ -19,6 +19,7 @@ export function configure(app: express.Application) {
 
   register(app, "getClassesByQuery", getClassesByQuery);
   register(app, "getReviewsByCourseId", getReviewsByCourseId);
+  register(app, "getCourseById", getCourseById);
 }
 
 function register<T>(app: express.Application, name: string, endpoint: Endpoint<T>) {

--- a/server/endpoints.ts
+++ b/server/endpoints.ts
@@ -1,12 +1,12 @@
 import express from "express";
 import { validationResult, ValidationChain } from "express-validator";
 import { getClassesByQuery } from "./endpoints/SearchBar";
-
+import { getReviewsByCourseId } from "./endpoints/Review";
 // A type which captures an endpoint, and the guard for that endpoint
 // INVARIANT: If an object passes the guard, it can be coerced into type T
 export interface Endpoint<T> {
-    guard: ValidationChain[];
-    callback: (args: T) => any;
+  guard: ValidationChain[];
+  callback: (args: T) => any;
 }
 
 /*
@@ -18,6 +18,7 @@ export function configure(app: express.Application) {
   app.use(express.json());
 
   register(app, "getClassesByQuery", getClassesByQuery);
+  register(app, "getReviewsByCourseId", getReviewsByCourseId);
 }
 
 function register<T>(app: express.Application, name: string, endpoint: Endpoint<T>) {

--- a/server/endpoints/Review.test.ts
+++ b/server/endpoints/Review.test.ts
@@ -3,13 +3,14 @@ import { MongoMemoryServer } from 'mongodb-memory-server';
 import express from "express";
 
 import axios from 'axios';
+import { Review } from 'common';
 import { configure } from "../endpoints";
-import { Classes, Reviews } from "../dbDefs";
+import { Classes, Students, Subjects, Reviews } from "../dbDefs";
 
 let mongoServer: MongoMemoryServer;
 let serverCloseHandle;
 
-const testingPort = 8000;
+const testingPort = 37760;
 
 beforeAll(async () => {
   // get mongoose all set up
@@ -74,11 +75,11 @@ beforeAll(async () => {
 afterAll(async () => {
   await mongoose.disconnect();
   await mongoServer.stop();
-  await serverCloseHandle.close();
+  serverCloseHandle.close();
 });
 
 describe('tests', () => {
-  it('getReviewsByCourseId - posting review', async () => {
+  it('getClassesByQuery-works', async () => {
     const res = await axios.post(`http://localhost:${testingPort}/v2/getReviewsByCourseId`, { courseId: "oH37S3mJ4eAsktypy" });
     expect(res.data.result.length).toBe(2);
   });

--- a/server/endpoints/Review.test.ts
+++ b/server/endpoints/Review.test.ts
@@ -9,7 +9,7 @@ import { Classes, Reviews } from "../dbDefs";
 let mongoServer: MongoMemoryServer;
 let serverCloseHandle;
 
-const testingPort = 37760;
+const testingPort = 8000;
 
 beforeAll(async () => {
   // get mongoose all set up
@@ -62,9 +62,9 @@ beforeAll(async () => {
     reported: 0,
   });
 
-  await review2.save();
-  await review1.save();
-  await c2110.save();
+  review2.save();
+  review1.save();
+  c2110.save();
   // Set up a mock version of the v2 endpoints to test against
   const app = express();
   serverCloseHandle = app.listen(testingPort, async () => { });
@@ -74,11 +74,11 @@ beforeAll(async () => {
 afterAll(async () => {
   await mongoose.disconnect();
   await mongoServer.stop();
-  serverCloseHandle.close();
+  await serverCloseHandle.close();
 });
 
 describe('tests', () => {
-  it('getClassesByQuery-works', async () => {
+  it('getReviewsByCourseId - posting review', async () => {
     const res = await axios.post(`http://localhost:${testingPort}/v2/getReviewsByCourseId`, { courseId: "oH37S3mJ4eAsktypy" });
     expect(res.data.result.length).toBe(2);
   });

--- a/server/endpoints/Review.test.ts
+++ b/server/endpoints/Review.test.ts
@@ -3,14 +3,13 @@ import { MongoMemoryServer } from 'mongodb-memory-server';
 import express from "express";
 
 import axios from 'axios';
-import { Review } from 'common';
 import { configure } from "../endpoints";
-import { Classes, Students, Subjects, Reviews } from "../dbDefs";
+import { Classes, Reviews } from "../dbDefs";
 
 let mongoServer: MongoMemoryServer;
 let serverCloseHandle;
 
-const testingPort = 37760;
+const testingPort = 8000;
 
 beforeAll(async () => {
   // get mongoose all set up
@@ -75,11 +74,11 @@ beforeAll(async () => {
 afterAll(async () => {
   await mongoose.disconnect();
   await mongoServer.stop();
-  serverCloseHandle.close();
+  await serverCloseHandle.close();
 });
 
 describe('tests', () => {
-  it('getClassesByQuery-works', async () => {
+  it('getReviewsByCourseId - posting review', async () => {
     const res = await axios.post(`http://localhost:${testingPort}/v2/getReviewsByCourseId`, { courseId: "oH37S3mJ4eAsktypy" });
     expect(res.data.result.length).toBe(2);
   });

--- a/server/endpoints/Review.test.ts
+++ b/server/endpoints/Review.test.ts
@@ -3,9 +3,8 @@ import { MongoMemoryServer } from 'mongodb-memory-server';
 import express from "express";
 
 import axios from 'axios';
-import { Review } from 'common';
 import { configure } from "../endpoints";
-import { Classes, Students, Subjects, Reviews } from "../dbDefs";
+import { Classes, Reviews } from "../dbDefs";
 
 let mongoServer: MongoMemoryServer;
 let serverCloseHandle;

--- a/server/endpoints/Review.test.ts
+++ b/server/endpoints/Review.test.ts
@@ -31,6 +31,8 @@ afterAll(async () => {
 
 describe('tests', () => {
   it('getClassesByQuery-works', async () => {
-
+    const res = await axios.post(`http://localhost:${testingPort}/v2/getReviewsByCourseId`, { courseId: "dsjkdhjqe" });
+    console.log("review test: ", res.data);
+    expect(1).toBe(1);
   });
 });

--- a/server/endpoints/Review.test.ts
+++ b/server/endpoints/Review.test.ts
@@ -3,8 +3,9 @@ import { MongoMemoryServer } from 'mongodb-memory-server';
 import express from "express";
 
 import axios from 'axios';
+import { Review } from 'common';
 import { configure } from "../endpoints";
-import { Classes, Students, Subjects } from "../dbDefs";
+import { Classes, Students, Subjects, Reviews } from "../dbDefs";
 
 let mongoServer: MongoMemoryServer;
 let serverCloseHandle;
@@ -17,6 +18,54 @@ beforeAll(async () => {
   const mongoUri = await mongoServer.getUri();
   await mongoose.connect(mongoUri, { useNewUrlParser: true, useUnifiedTopology: true });
 
+  const c2110 = new Classes({
+    _id: "oH37S3mJ4eAsktypy",
+    classSub: "cs",
+    classNum: "2110",
+    classTitle: "Object-Oriented Programming and Data Structures",
+    classPrereq: [],
+    classFull: "cs 2110 object-oriented programming and data structures",
+    classSems: ["FA14", "SP15", "SU15", "FA15", "SP16", "SU16", "FA16", "SP17",
+      "SU17", "FA17", "SP18", "FA18", "SU18", "SP19", "FA19", "SU19"],
+    crossList: ["q75SxmqkTFEfaJwZ3"],
+    classProfessors: ["David Gries", "Douglas James", "Siddhartha Chaudhuri",
+      "Graeme Bailey", "John Foster", "Ross Tate", "Michael George",
+      "Eleanor Birrell", "Adrian Sampson", "Natacha Crooks", "Anne Bracy",
+      "Michael Clarkson"],
+    classDifficulty: 2.9,
+    classRating: null,
+    classWorkload: 3,
+  });
+
+  const review1 = new Reviews({
+    _id: "4Y8k7DnX3PLNdwRPr",
+    text: "review text for cs 2110",
+    difficulty: 1,
+    quality: 4,
+    class: "oH37S3mJ4eAsktypy",
+    grade: 6,
+    date: new Date().toISOString(),
+    atten: 0,
+    visible: 1,
+    reported: 0,
+  });
+
+  const review2 = new Reviews({
+    _id: "4Y8k7DnX3PLNdwRPq",
+    text: "review text for cs 2110 number 2",
+    difficulty: 1,
+    quality: 5,
+    class: "oH37S3mJ4eAsktypy",
+    grade: 6,
+    date: new Date().toISOString(),
+    atten: 0,
+    visible: 1,
+    reported: 0,
+  });
+
+  review2.save();
+  review1.save();
+  c2110.save();
   // Set up a mock version of the v2 endpoints to test against
   const app = express();
   serverCloseHandle = app.listen(testingPort, async () => { });
@@ -31,8 +80,8 @@ afterAll(async () => {
 
 describe('tests', () => {
   it('getClassesByQuery-works', async () => {
-    const res = await axios.post(`http://localhost:${testingPort}/v2/getReviewsByCourseId`, { courseId: "dsjkdhjqe" });
-    console.log("review test: ", res.data);
+    const res = await axios.post(`http://localhost:${testingPort}/v2/getReviewsByCourseId`, { courseId: "oH37S3mJ4eAsktypy" });
+    expect(res.data.result.length).toBe(2);
     expect(1).toBe(1);
   });
 });

--- a/server/endpoints/Review.test.ts
+++ b/server/endpoints/Review.test.ts
@@ -148,4 +148,9 @@ describe('tests', () => {
     expect(res.data.result._id).toBe("oH37S3mJ4eAsktypy");
     expect(res.data.result.classTitle).toBe("Object-Oriented Programming and Data Structures");
   });
+
+  it("getReviewsByCourseId - getting review for a class that does not exist", async () => {
+    const res = await axios.post(`http://localhost:${testingPort}/v2/getReviewsByCourseId`, { courseId: "ert" });
+    expect(res.data.result).toEqual({ error: 'Invalid course id' });
+  });
 });

--- a/server/endpoints/Review.test.ts
+++ b/server/endpoints/Review.test.ts
@@ -62,9 +62,9 @@ beforeAll(async () => {
     reported: 0,
   });
 
-  review2.save();
-  review1.save();
-  c2110.save();
+  await review2.save();
+  await review1.save();
+  await c2110.save();
   // Set up a mock version of the v2 endpoints to test against
   const app = express();
   serverCloseHandle = app.listen(testingPort, async () => { });

--- a/server/endpoints/Review.test.ts
+++ b/server/endpoints/Review.test.ts
@@ -88,7 +88,7 @@ afterAll(async () => {
 describe('tests', () => {
   it('getReviewsByCourseId - getting review', async () => {
     const res = await axios.post(`http://localhost:${testingPort}/v2/getReviewsByCourseId`, { courseId: "oH37S3mJ4eAsktypy" });
-    expect(res.data.result.length).toBe(2);
+    expect(res.data.result.length).toBe(testReviews.length);
 
     const classOfReviews = testReviews.map((r) => r.class);
     expect(res.data.result.map((r) => r.class).sort()).toEqual(classOfReviews.sort());

--- a/server/endpoints/Review.test.ts
+++ b/server/endpoints/Review.test.ts
@@ -72,55 +72,6 @@ beforeAll(async () => {
   await Promise.all(
     testReviews.map(async (r) => await (new Reviews(r).save())),
   );
-  /* const c2110 = new Classes({
-    _id: "oH37S3mJ4eAsktypy",
-    classSub: "cs",
-    classNum: "2110",
-    classTitle: "Object-Oriented Programming and Data Structures",
-    classPrereq: [],
-    classFull: "cs 2110 object-oriented programming and data structures",
-    classSems: ["FA14", "SP15", "SU15", "FA15", "SP16", "SU16", "FA16", "SP17",
-      "SU17", "FA17", "SP18", "FA18", "SU18", "SP19", "FA19", "SU19"],
-    crossList: ["q75SxmqkTFEfaJwZ3"],
-    classProfessors: ["David Gries", "Douglas James", "Siddhartha Chaudhuri",
-      "Graeme Bailey", "John Foster", "Ross Tate", "Michael George",
-      "Eleanor Birrell", "Adrian Sampson", "Natacha Crooks", "Anne Bracy",
-      "Michael Clarkson"],
-    classDifficulty: 2.9,
-    classRating: null,
-    classWorkload: 3,
-  });
-
-  const review1 = new Reviews({
-    _id: "4Y8k7DnX3PLNdwRPr",
-    text: "review text for cs 2110",
-    difficulty: 1,
-    quality: 4,
-    class: "oH37S3mJ4eAsktypy",
-    grade: 6,
-    date: new Date().toISOString(),
-    atten: 0,
-    visible: 1,
-    reported: 0,
-  });
-
-  const review2 = new Reviews({
-    _id: "4Y8k7DnX3PLNdwRPq",
-    text: "review text for cs 2110 number 2",
-    difficulty: 1,
-    quality: 5,
-    class: "oH37S3mJ4eAsktypy",
-    grade: 6,
-    date: new Date().toISOString(),
-    atten: 0,
-    visible: 1,
-    reported: 0,
-  });
-
-  await review2.save();
-  await review1.save();
-  await c2110.save();
-  */
 
   // Set up a mock version of the v2 endpoints to test against
   const app = express();

--- a/server/endpoints/Review.test.ts
+++ b/server/endpoints/Review.test.ts
@@ -82,6 +82,5 @@ describe('tests', () => {
   it('getClassesByQuery-works', async () => {
     const res = await axios.post(`http://localhost:${testingPort}/v2/getReviewsByCourseId`, { courseId: "oH37S3mJ4eAsktypy" });
     expect(res.data.result.length).toBe(2);
-    expect(1).toBe(1);
   });
 });

--- a/server/endpoints/Review.test.ts
+++ b/server/endpoints/Review.test.ts
@@ -11,13 +11,68 @@ let serverCloseHandle;
 
 const testingPort = 8000;
 
+const testClasses = [
+  {
+    _id: "oH37S3mJ4eAsktypy",
+    classSub: "cs",
+    classNum: "2110",
+    classTitle: "Object-Oriented Programming and Data Structures",
+    classPrereq: [],
+    classFull: "cs 2110 object-oriented programming and data structures",
+    classSems: ["FA14", "SP15", "SU15", "FA15", "SP16", "SU16", "FA16", "SP17",
+      "SU17", "FA17", "SP18", "FA18", "SU18", "SP19", "FA19", "SU19"],
+    crossList: ["q75SxmqkTFEfaJwZ3"],
+    classProfessors: ["David Gries", "Douglas James", "Siddhartha Chaudhuri",
+      "Graeme Bailey", "John Foster", "Ross Tate", "Michael George",
+      "Eleanor Birrell", "Adrian Sampson", "Natacha Crooks", "Anne Bracy",
+      "Michael Clarkson"],
+    classDifficulty: 2.9,
+    classRating: null,
+    classWorkload: 3,
+  },
+];
+
+const testReviews = [
+  {
+    _id: "4Y8k7DnX3PLNdwRPr",
+    text: "review text for cs 2110",
+    difficulty: 1,
+    quality: 4,
+    class: "oH37S3mJ4eAsktypy",
+    grade: 6,
+    date: new Date().toISOString(),
+    atten: 0,
+    visible: 1,
+    reported: 0,
+  },
+  {
+    _id: "4Y8k7DnX3PLNdwRPq",
+    text: "review text for cs 2110 number 2",
+    difficulty: 1,
+    quality: 5,
+    class: "oH37S3mJ4eAsktypy",
+    grade: 6,
+    date: new Date().toISOString(),
+    atten: 0,
+    visible: 1,
+    reported: 0,
+  },
+];
+
 beforeAll(async () => {
   // get mongoose all set up
   mongoServer = new MongoMemoryServer();
   const mongoUri = await mongoServer.getUri();
   await mongoose.connect(mongoUri, { useNewUrlParser: true, useUnifiedTopology: true });
 
-  const c2110 = new Classes({
+  await Promise.all(
+    testClasses.map(async (c) => await (new Classes(c).save())),
+  );
+
+  await Promise.all(
+    testReviews.map(async (r) => await (new Reviews(r).save())),
+  );
+  /* const c2110 = new Classes({
     _id: "oH37S3mJ4eAsktypy",
     classSub: "cs",
     classNum: "2110",
@@ -65,6 +120,8 @@ beforeAll(async () => {
   await review2.save();
   await review1.save();
   await c2110.save();
+  */
+
   // Set up a mock version of the v2 endpoints to test against
   const app = express();
   serverCloseHandle = app.listen(testingPort, async () => { });
@@ -78,8 +135,17 @@ afterAll(async () => {
 });
 
 describe('tests', () => {
-  it('getReviewsByCourseId - posting review', async () => {
+  it('getReviewsByCourseId - getting review', async () => {
     const res = await axios.post(`http://localhost:${testingPort}/v2/getReviewsByCourseId`, { courseId: "oH37S3mJ4eAsktypy" });
     expect(res.data.result.length).toBe(2);
+
+    const classOfReviews = testReviews.map((r) => r.class);
+    expect(res.data.result.map((r) => r.class).sort()).toEqual(classOfReviews.sort());
+  });
+
+  it("getCourseById - getting cs2110", async () => {
+    const res = await axios.post(`http://localhost:${testingPort}/v2/getCourseById`, { courseId: "oH37S3mJ4eAsktypy" });
+    expect(res.data.result._id).toBe("oH37S3mJ4eAsktypy");
+    expect(res.data.result.classTitle).toBe("Object-Oriented Programming and Data Structures");
   });
 });

--- a/server/endpoints/Review.test.ts
+++ b/server/endpoints/Review.test.ts
@@ -1,0 +1,36 @@
+import mongoose from 'mongoose';
+import { MongoMemoryServer } from 'mongodb-memory-server';
+import express from "express";
+
+import axios from 'axios';
+import { configure } from "../endpoints";
+import { Classes, Students, Subjects } from "../dbDefs";
+
+let mongoServer: MongoMemoryServer;
+let serverCloseHandle;
+
+const testingPort = 37760;
+
+beforeAll(async () => {
+  // get mongoose all set up
+  mongoServer = new MongoMemoryServer();
+  const mongoUri = await mongoServer.getUri();
+  await mongoose.connect(mongoUri, { useNewUrlParser: true, useUnifiedTopology: true });
+
+  // Set up a mock version of the v2 endpoints to test against
+  const app = express();
+  serverCloseHandle = app.listen(testingPort, async () => { });
+  configure(app);
+});
+
+afterAll(async () => {
+  await mongoose.disconnect();
+  await mongoServer.stop();
+  serverCloseHandle.close();
+});
+
+describe('tests', () => {
+  it('getClassesByQuery-works', async () => {
+
+  });
+});

--- a/server/endpoints/Review.ts
+++ b/server/endpoints/Review.ts
@@ -1,0 +1,33 @@
+import { body } from "express-validator";
+import { Endpoint } from "../endpoints";
+import { Meteor } from "../shim";
+import { Reviews } from "../dbDefs";
+
+interface CourseId {
+  courseId: string;
+}
+// eslint-disable-next-line import/prefer-default-export
+export const getReviewsByCourseId = (): Endpoint<CourseId> => ({
+  guard: [body("courseId").notEmpty().isAscii()],
+  callback: async (courseId: CourseId) => {
+    try {
+      const regex = new RegExp(/^(?=.*[A-Z])/i);
+      if (regex.test(courseId.courseId)) {
+        const course = await Meteor.call("getCourseById", courseId);
+        if (course) {
+          const crossListOR = getCrossListOR(course);
+          const reviews = await Reviews.find({ visible: 1, reported: 0, $or: crossListOR }, {}, { sort: { date: -1 }, limit: 700 }).exec();
+          return reviews;
+        }
+        return null;
+      }
+      return null;
+    } catch (error) {
+      // eslint-disable-next-line no-console
+      console.log("Error: at 'getReviewsByCourseId' method");
+      // eslint-disable-next-line no-console
+      console.log(error);
+      return null;
+    }
+  },
+});

--- a/server/endpoints/Review.ts
+++ b/server/endpoints/Review.ts
@@ -7,10 +7,6 @@ interface CourseId {
   courseId: string;
 }
 
-/**
- * Get a course with this course_id from the Classes collection in the local 
- * database.
- */
 export const getCourseById: Endpoint<CourseId> = {
   guard: [body("courseId").notEmpty().isAscii()],
   callback: async (courseId: CourseId) => {
@@ -31,10 +27,7 @@ export const getCourseById: Endpoint<CourseId> = {
   },
 };
 
-/**
- * Get list of review objects for given class from class _id
- * Accounts for cross-listed reviews
- */
+// eslint-disable-next-line import/prefer-default-export
 export const getReviewsByCourseId: Endpoint<CourseId> = {
   guard: [body("courseId").notEmpty().isAscii()],
   callback: async (courseId: CourseId) => {

--- a/server/endpoints/Review.ts
+++ b/server/endpoints/Review.ts
@@ -27,7 +27,9 @@ export const getCourseById: Endpoint<CourseId> = {
   },
 };
 
-// eslint-disable-next-line import/prefer-default-export
+/**
+ * Get list of review objects for given class from class _id
+ */
 export const getReviewsByCourseId: Endpoint<CourseId> = {
   guard: [body("courseId").notEmpty().isAscii()],
   callback: async (courseId: CourseId) => {

--- a/server/endpoints/Review.ts
+++ b/server/endpoints/Review.ts
@@ -7,6 +7,10 @@ interface CourseId {
   courseId: string;
 }
 
+/**
+ * Get a course with this course_id from the Classes collection in the local 
+ * database.
+ */
 export const getCourseById: Endpoint<CourseId> = {
   guard: [body("courseId").notEmpty().isAscii()],
   callback: async (courseId: CourseId) => {
@@ -27,7 +31,10 @@ export const getCourseById: Endpoint<CourseId> = {
   },
 };
 
-// eslint-disable-next-line import/prefer-default-export
+/**
+ * Get list of review objects for given class from class _id
+ * Accounts for cross-listed reviews
+ */
 export const getReviewsByCourseId: Endpoint<CourseId> = {
   guard: [body("courseId").notEmpty().isAscii()],
   callback: async (courseId: CourseId) => {

--- a/server/endpoints/Review.ts
+++ b/server/endpoints/Review.ts
@@ -8,9 +8,12 @@ interface CourseId {
   courseId: string;
 }
 // eslint-disable-next-line import/prefer-default-export
-export const getReviewsByCourseId = (): Endpoint<CourseId> => ({
+export const getReviewsByCourseId: Endpoint<CourseId> = {
   guard: [body("courseId").notEmpty().isAscii()],
   callback: async (courseId: CourseId) => {
+    console.log("called getReviewsByCourseId");
+    return null;
+
     try {
       const regex = new RegExp(/^(?=.*[A-Z])/i);
       if (regex.test(courseId.courseId)) {
@@ -31,4 +34,4 @@ export const getReviewsByCourseId = (): Endpoint<CourseId> => ({
       return null;
     }
   },
-});
+};

--- a/server/endpoints/Review.ts
+++ b/server/endpoints/Review.ts
@@ -1,7 +1,6 @@
 import { body } from "express-validator";
 import { getCrossListOR } from "common/CourseCard";
 import { Endpoint } from "../endpoints";
-import { Meteor } from "../shim";
 import { Reviews, Classes } from "../dbDefs";
 
 interface CourseId {

--- a/server/endpoints/Review.ts
+++ b/server/endpoints/Review.ts
@@ -8,8 +8,7 @@ interface CourseId {
 }
 
 /**
- * Get a course with this course_id from the Classes collection in the local
- * database.
+ * Get a course with this course_id from the Classes collection
  */
 export const getCourseById: Endpoint<CourseId> = {
   guard: [body("courseId").notEmpty().isAscii()],
@@ -20,13 +19,13 @@ export const getCourseById: Endpoint<CourseId> = {
       if (regex.test(courseId.courseId)) {
         return await Classes.findOne({ _id: courseId.courseId }).exec();
       }
-      return null;
+      return { error: "Malformed Query" };
     } catch (error) {
       // eslint-disable-next-line no-console
       console.log("Error: at 'getCourseById' method");
       // eslint-disable-next-line no-console
       console.log(error);
-      return null;
+      return { error: "Internal Server Error" };
     }
   },
 };
@@ -46,15 +45,15 @@ export const getReviewsByCourseId: Endpoint<CourseId> = {
           const reviews = await Reviews.find({ visible: 1, reported: 0, $or: crossListOR }, {}, { sort: { date: -1 }, limit: 700 }).exec();
           return reviews;
         }
-        return null;
+        return { error: "Invalid course id" };
       }
-      return null;
+      return { error: "Malformed Query" };
     } catch (error) {
       // eslint-disable-next-line no-console
       console.log("Error: at 'getReviewsByCourseId' method");
       // eslint-disable-next-line no-console
       console.log(error);
-      return null;
+      return { error: "Internal Server Error" };
     }
   },
 };

--- a/server/endpoints/Review.ts
+++ b/server/endpoints/Review.ts
@@ -2,22 +2,40 @@ import { body } from "express-validator";
 import { getCrossListOR } from "common/CourseCard";
 import { Endpoint } from "../endpoints";
 import { Meteor } from "../shim";
-import { Reviews } from "../dbDefs";
+import { Reviews, Classes } from "../dbDefs";
 
 interface CourseId {
   courseId: string;
 }
+
+export const getCourseById: Endpoint<CourseId> = {
+  guard: [body("courseId").notEmpty().isAscii()],
+  callback: async (courseId: CourseId) => {
+    try {
+      // check: make sure course id is valid and non-malicious
+      const regex = new RegExp(/^(?=.*[A-Z0-9])/i);
+      if (regex.test(courseId.courseId)) {
+        return await Classes.findOne({ _id: courseId.courseId }).exec();
+      }
+      return null;
+    } catch (error) {
+      // eslint-disable-next-line no-console
+      console.log("Error: at 'getCourseById' method");
+      // eslint-disable-next-line no-console
+      console.log(error);
+      return null;
+    }
+  },
+};
+
 // eslint-disable-next-line import/prefer-default-export
 export const getReviewsByCourseId: Endpoint<CourseId> = {
   guard: [body("courseId").notEmpty().isAscii()],
   callback: async (courseId: CourseId) => {
-    console.log("called getReviewsByCourseId");
-    return null;
-
     try {
       const regex = new RegExp(/^(?=.*[A-Z])/i);
       if (regex.test(courseId.courseId)) {
-        const course = await Meteor.call("getCourseById", courseId);
+        const course = await getCourseById.callback(courseId);
         if (course) {
           const crossListOR = getCrossListOR(course);
           const reviews = await Reviews.find({ visible: 1, reported: 0, $or: crossListOR }, {}, { sort: { date: -1 }, limit: 700 }).exec();

--- a/server/endpoints/Review.ts
+++ b/server/endpoints/Review.ts
@@ -7,6 +7,10 @@ interface CourseId {
   courseId: string;
 }
 
+/**
+ * Get a course with this course_id from the Classes collection in the local
+ * database.
+ */
 export const getCourseById: Endpoint<CourseId> = {
   guard: [body("courseId").notEmpty().isAscii()],
   callback: async (courseId: CourseId) => {

--- a/server/endpoints/Review.ts
+++ b/server/endpoints/Review.ts
@@ -1,4 +1,5 @@
 import { body } from "express-validator";
+import { getCrossListOR } from "common/CourseCard";
 import { Endpoint } from "../endpoints";
 import { Meteor } from "../shim";
 import { Reviews } from "../dbDefs";

--- a/server/endpoints/Review.ts
+++ b/server/endpoints/Review.ts
@@ -1,9 +1,10 @@
 import { body } from "express-validator";
 import { getCrossListOR } from "common/CourseCard";
 import { Endpoint } from "../endpoints";
-import { Reviews, Classes } from "../dbDefs";
+import { Reviews } from "../dbDefs";
+import { getCourseById as getCourseByIdCallback } from "./utils";
 
-interface CourseId {
+export interface CourseId {
   courseId: string;
 }
 
@@ -12,22 +13,7 @@ interface CourseId {
  */
 export const getCourseById: Endpoint<CourseId> = {
   guard: [body("courseId").notEmpty().isAscii()],
-  callback: async (courseId: CourseId) => {
-    try {
-      // check: make sure course id is valid and non-malicious
-      const regex = new RegExp(/^(?=.*[A-Z0-9])/i);
-      if (regex.test(courseId.courseId)) {
-        return await Classes.findOne({ _id: courseId.courseId }).exec();
-      }
-      return { error: "Malformed Query" };
-    } catch (error) {
-      // eslint-disable-next-line no-console
-      console.log("Error: at 'getCourseById' method");
-      // eslint-disable-next-line no-console
-      console.log(error);
-      return { error: "Internal Server Error" };
-    }
-  },
+  callback: getCourseByIdCallback,
 };
 
 /**
@@ -39,7 +25,7 @@ export const getReviewsByCourseId: Endpoint<CourseId> = {
     try {
       const regex = new RegExp(/^(?=.*[A-Z])/i);
       if (regex.test(courseId.courseId)) {
-        const course = await getCourseById.callback(courseId);
+        const course = await getCourseByIdCallback(courseId);
         if (course) {
           const crossListOR = getCrossListOR(course);
           const reviews = await Reviews.find({ visible: 1, reported: 0, $or: crossListOR }, {}, { sort: { date: -1 }, limit: 700 }).exec();

--- a/server/endpoints/SearchBar.test.ts
+++ b/server/endpoints/SearchBar.test.ts
@@ -74,7 +74,7 @@ beforeAll(async () => {
 
   // Set up a mock version of the v2 endpoints to test against
   const app = express();
-  serverCloseHandle = app.listen(testingPort, async () => { });
+  serverCloseHandle = app.listen(testingPort, async () => {});
   configure(app);
 });
 

--- a/server/endpoints/SearchBar.test.ts
+++ b/server/endpoints/SearchBar.test.ts
@@ -74,7 +74,7 @@ beforeAll(async () => {
 
   // Set up a mock version of the v2 endpoints to test against
   const app = express();
-  serverCloseHandle = app.listen(testingPort, async () => {});
+  serverCloseHandle = app.listen(testingPort, async () => { });
   configure(app);
 });
 

--- a/server/endpoints/utils.ts
+++ b/server/endpoints/utils.ts
@@ -1,0 +1,20 @@
+import { CourseId } from "./Review";
+import { Classes } from "../dbDefs";
+
+// eslint-disable-next-line import/prefer-default-export
+export const getCourseById = async (courseId: CourseId) => {
+  try {
+    // check: make sure course id is valid and non-malicious
+    const regex = new RegExp(/^(?=.*[A-Z0-9])/i);
+    if (regex.test(courseId.courseId)) {
+      return await Classes.findOne({ _id: courseId.courseId }).exec();
+    }
+    return { error: "Malformed Query" };
+  } catch (error) {
+    // eslint-disable-next-line no-console
+    console.log("Error: at 'getCourseById' method");
+    // eslint-disable-next-line no-console
+    console.log(error);
+    return { error: "Internal Server Error" };
+  }
+};


### PR DESCRIPTION
### Summary 

This pull request creates express endpoints for viewing reviews. Currently we have two meteor methods that do this: 
`getReviewsByCourseId` and `getReviewsByProfessor`. Doing a quick search through the project shows that `getReviewsByProfessor` is not used anywhere, so this PR will have `getReviewsByCourseId` and `getCourseById` (used in `getReviewsByCourseId`). Other endpoints for reviews that change data ex: makeVisible, reportReview are not included in this PR for viewing reviews.

### Test Plan 
Added tests in `server/endpoints/Review.test.ts`

### Notes 
Currently it seems like we are organizing endpoints by where they are used. EX: `getClassesByQuery` is used in `SearchBar` so we put it in `SearchBar.ts`. Looking through the meteor methods we have, however, I don't think such a method would work very well as many functions are used in multiple places. I think it would be better if we split endpoints by their jobs. For example, all endpoints that have to do with getting/updating reviews would go in a file `Review.ts` and endpoints dealing with auth ex: `tokenIsAdmin` would go in `Auth.ts` and so on.
