### PR TITLE
Create Remaining Search Bar Endpoints

### DIFF
--- a/server/endpoints.ts
+++ b/server/endpoints.ts
@@ -1,6 +1,6 @@
 import express from "express";
 import { validationResult, ValidationChain } from "express-validator";
-import { getClassesByQuery } from "./endpoints/SearchBar";
+import { getClassesByQuery, getSubjectsByQuery, getProfessorsByQuery } from "./endpoints/Search";
 
 // A type which captures an endpoint, and the guard for that endpoint
 // INVARIANT: If an object passes the guard, it can be coerced into type T
@@ -18,6 +18,8 @@ export function configure(app: express.Application) {
   app.use(express.json());
 
   register(app, "getClassesByQuery", getClassesByQuery);
+  register(app, "getSubjectsByQuery", getSubjectsByQuery);
+  register(app, "getProfessorsByQuery", getProfessorsByQuery);
 }
 
 function register<T>(app: express.Application, name: string, endpoint: Endpoint<T>) {

--- a/server/endpoints/Search.ts
+++ b/server/endpoints/Search.ts
@@ -1,7 +1,7 @@
 import { body } from "express-validator";
 
 import { Endpoint } from "../endpoints";
-import { Classes } from "../dbDefs";
+import { Classes, Subjects, Professors } from "../dbDefs";
 
 // The type for a search query
 interface Search {
@@ -72,7 +72,51 @@ export const getClassesByQuery: Endpoint<Search> = {
       return { error: "Malformed Query" };
     } catch (error) {
       // eslint-disable-next-line no-console
-      console.log("Error: at 'getClassesByQuery' method");
+      console.log("Error: at 'getClassesByQuery' endpoint");
+      // eslint-disable-next-line no-console
+      console.log(error);
+      return { error: "Internal Server Error" };
+    }
+  },
+};
+
+/*
+ * Searches the database on Subjects using the text index and returns matching subjects
+ */
+export const getSubjectsByQuery: Endpoint<Search> = {
+  guard: [body("query").notEmpty().isAscii()],
+  callback: async (search: Search) => {
+    try {
+      const regex = new RegExp(/^(?=.*[A-Z0-9])/i);
+      if (regex.test(search.query)) {
+        return await Subjects.find({ $text: { $search: search.query } }, { score: { $meta: "textScore" } }, { sort: { score: { $meta: "textScore" } } }).exec();
+      }
+      return { error: "Malformed Query" };
+    } catch (error) {
+      // eslint-disable-next-line no-console
+      console.log("Error: at 'getSubjectsByQuery' endpoint");
+      // eslint-disable-next-line no-console
+      console.log(error);
+      return { error: "Internal Server Error" };
+    }
+  },
+};
+
+/*
+ * Searches the database on Professors using the text index and returns matching professors
+ */
+export const getProfessorsByQuery: Endpoint<Search> = {
+  guard: [body("query").notEmpty().isAscii()],
+  callback: async (seach: Search) => {
+    try {
+      const regex = new RegExp(/^(?=.*[A-Z0-9])/i);
+      if (regex.test(seach.query)) {
+        return await Professors.find({ $text: { $search: seach.query } }, { score: { $meta: "textScore" } }, { sort: { score: { $meta: "textScore" } } }).exec();
+      }
+      return { error: "Malformed Query" };
+    } catch (error) {
+      // eslint-disable-next-line no-console
+      console.log("Error: at 'getProfessorsByQuery' endpoint");
       // eslint-disable-next-line no-console
       console.log(error);
       return { error: "Internal Server Error" };

--- a/server/tsconfig.json
+++ b/server/tsconfig.json
@@ -8,5 +8,5 @@
         "downlevelIteration": true,
         "outDir": "dist"
     },
-    "files": ["dbInit.ts", "dbDefs.ts", "publications.ts", "methods.ts", "shim.ts", "server.ts", "endpoints.ts", "endpoints/SearchBar.ts"]
+    "files": ["dbInit.ts", "dbDefs.ts", "publications.ts", "methods.ts", "shim.ts", "server.ts", "endpoints.ts", "endpoints/Search.ts"]
 }


### PR DESCRIPTION
### Summary <!-- Required -->

This pull request implements the rest of the publicly available endpoints for searching informatio about classes.

In accordance with some comments on, a previous PR, I changed the name from SearchBar to Search for this functionality.

### Test Plan <!-- Required -->

See the additional tests in `Search.test.ts` for the endpoints that were added.

### Notes <!-- Optional -->

Creating this PR revealed an issue with mongodb we should look into some more. In particular, the question is about mongo's indexes, which are somehow tied implicitly to the db. We should move a way from this as it leads to subtly different behavior on testing/local/staging/prod. In particular, I think we should make it more explcit with something like this: https://www.npmjs.com/package/mongoose-text-search , but let me know what you guys think.

### Breaking Changes  <!-- Optional -->

None yet, deprecation will be a seperate PR.
