### PR TITLE
Express endpoints for admin authenticated endpoints

### DIFF
--- a/server/endpoints.ts
+++ b/server/endpoints.ts
@@ -2,6 +2,7 @@ import express from "express";
 import { validationResult, ValidationChain } from "express-validator";
 import { tokenIsAdmin } from "./endpoints/Auth";
 import { getClassesByQuery, getSubjectsByQuery, getProfessorsByQuery } from "./endpoints/Search";
+import { makeReviewVisible } from "./endpoints/AdminActions";
 
 // A type which captures an endpoint, and the guard for that endpoint
 // INVARIANT: If an object passes the guard, it can be coerced into type T
@@ -22,6 +23,7 @@ export function configure(app: express.Application) {
   register(app, "tokenIsAdmin", tokenIsAdmin);
   register(app, "getSubjectsByQuery", getSubjectsByQuery);
   register(app, "getProfessorsByQuery", getProfessorsByQuery);
+  register(app, "makeReviewVisible", makeReviewVisible);
 }
 
 function register<T>(app: express.Application, name: string, endpoint: Endpoint<T>) {

--- a/server/endpoints.ts
+++ b/server/endpoints.ts
@@ -3,7 +3,7 @@ import { validationResult, ValidationChain } from "express-validator";
 import { getReviewsByCourseId, getCourseById } from "./endpoints/Review";
 import { tokenIsAdmin } from "./endpoints/Auth";
 import { getClassesByQuery, getSubjectsByQuery, getProfessorsByQuery } from "./endpoints/Search";
-import { makeReviewVisible } from "./endpoints/AdminActions";
+import { makeReviewVisible, undoReportReview, removeReview } from "./endpoints/AdminActions";
 
 // A type which captures an endpoint, and the guard for that endpoint
 // INVARIANT: If an object passes the guard, it can be coerced into type T
@@ -27,6 +27,8 @@ export function configure(app: express.Application) {
   register(app, "getSubjectsByQuery", getSubjectsByQuery);
   register(app, "getProfessorsByQuery", getProfessorsByQuery);
   register(app, "makeReviewVisible", makeReviewVisible);
+  register(app, "undoReportReview", undoReportReview);
+  register(app, "removeReview", removeReview);
 }
 
 function register<T>(app: express.Application, name: string, endpoint: Endpoint<T>) {

--- a/server/endpoints/AdminActions.test.ts
+++ b/server/endpoints/AdminActions.test.ts
@@ -6,8 +6,7 @@ import { TokenPayload } from 'google-auth-library/build/src/auth/loginticket';
 
 import { configure } from "../endpoints";
 import { Classes, Reviews } from "../dbDefs";
-import { getCourseById } from "./utils";
-import * as Utils from "./Utils";
+import * as Utils from "./utils";
 
 let mongoServer: MongoMemoryServer;
 let serverCloseHandle;

--- a/server/endpoints/AdminActions.test.ts
+++ b/server/endpoints/AdminActions.test.ts
@@ -7,11 +7,11 @@ import { TokenPayload } from 'google-auth-library/build/src/auth/loginticket';
 import { configure } from "../endpoints";
 import { Classes, Reviews } from "../dbDefs";
 import { getCourseById } from "./utils";
-import * as Auth from "./Auth";
+import * as Utils from "./Utils";
 
 let mongoServer: MongoMemoryServer;
 let serverCloseHandle;
-const mockVerification = jest.spyOn(Auth, 'verifyToken').mockImplementation(async (token? : string) => true);
+const mockVerification = jest.spyOn(Utils, 'verifyToken').mockImplementation(async (token? : string) => true);
 
 const testingPort = 37728;
 

--- a/server/endpoints/AdminActions.test.ts
+++ b/server/endpoints/AdminActions.test.ts
@@ -1,0 +1,131 @@
+import mongoose from 'mongoose';
+import { MongoMemoryServer } from 'mongodb-memory-server';
+import express from "express";
+import axios from 'axios';
+import { TokenPayload } from 'google-auth-library/build/src/auth/loginticket';
+
+import { configure } from "../endpoints";
+import { Classes, Reviews } from "../dbDefs";
+import * as Auth from "./Auth";
+import { undoReportReview } from './AdminActions';
+
+let mongoServer: MongoMemoryServer;
+let serverCloseHandle;
+
+const testingPort = 37760;
+
+const sampleReviewId = "sample-review";
+const reviewToUndoReportId = "review-to-undo-report";
+
+const newCourse1 = new Classes({
+  _id: "newCourse1",
+  classSub: "MORK",
+  classNum: "1110",
+  classTitle: "Introduction to Testing",
+  classFull: "MORK 1110: Introduction to Testing",
+  classSems: ["FA19"],
+  classProfessors: ["Gazghul Thraka"],
+  classRating: 0,
+  classWorkload: 0,
+  classDifficulty: 0,
+});
+
+const sampleReview = new Reviews({
+  _id: sampleReviewId,
+  visible: 0,
+  class: newCourse1._id,
+  difficulty: 1,
+  rating: 1,
+  workload: 1,
+});
+
+const reviewToUndoReport = new Reviews({
+  _id: reviewToUndoReportId,
+  reported: 1,
+  visible: 1,
+  class: newCourse1._id,
+  difficulty: 5,
+  rating: 5,
+  workload: 5,
+});
+
+const adminUser = new Students({
+    _id: "Irrelevant2",
+    firstName: "Dan Thomas",
+    lastName: "Ivy",
+    netId: "dti1",
+    affiliation: null,
+    token: "fakeTokenDti1",
+    privilege: "admin",
+  });
+
+  const validTokenPayload: TokenPayload = {
+    email: 'dti1@cornell.edu',
+    iss: undefined,
+    sub: undefined,
+    iat: undefined,
+    aud: undefined,
+    exp: undefined,
+  };
+
+beforeAll(async () => {
+  // get mongoose all set up
+  mongoServer = new MongoMemoryServer();
+  const mongoUri = await mongoServer.getUri();
+  await mongoose.connect(mongoUri, { useNewUrlParser: true, useUnifiedTopology: true });
+
+  await newCourse1.save();
+  await adminUser.save();
+
+  // Set up a mock version of the v2 endpoints to test against
+  const app = express();
+  serverCloseHandle = app.listen(testingPort, async () => {});
+  configure(app);
+});
+
+afterAll(async () => {
+  await mongoose.disconnect();
+  await mongoServer.stop();
+  serverCloseHandle.close();
+});
+
+describe('tests', () => {
+  it('makeReviewVisible-works', async () => {
+    const mockVerificationTicket = jest.spyOn(Auth, 'getVerificationTicket').mockImplementation(async (token? : string) => validTokenPayload);
+    await sampleReview.save();
+    const res = await axios.post(`http://localhost:${testingPort}/v2/makeReviewVisible`, { review: sampleReview, token: "non-empty" });
+    expect(res.data.result).toEqual(1);
+    const course = await Classes.findById("newCourse1");
+    expect(course.classDifficulty).toEqual(sampleReview.difficulty);
+    expect(course.classWorkload).toEqual(sampleReview.workload);
+    expect(course.classRating).toEqual(sampleReview.rating);
+
+    mockVerificationTicket.mockRestore();
+  });
+
+  it('undoReportReview-works', async () => {
+    const mockVerificationTicket = jest.spyOn(Auth, 'getVerificationTicket').mockImplementation(async (token? : string) => validTokenPayload);
+    await reviewToUndoReport.save();
+    const res = await axios.post(`http://localhost:${testingPort}/v2/undoReportReview`, { review: reviewToUndoReport, token: "non-empty" });
+    expect(res.data.result).toEqual(1);
+    const course = await Classes.findById("newCourse1");
+    expect(course.classDifficulty).toEqual(reviewToUndoReport.difficulty);
+    expect(course.classWorkload).toEqual(reviewToUndoReport.workload);
+    expect(course.classRating).toEqual(reviewToUndoReport.rating);
+
+    mockVerificationTicket.mockRestore();
+  });
+
+  it('removeReview-works', async () => {
+    const mockVerificationTicket = jest.spyOn(Auth, 'getVerificationTicket').mockImplementation(async (token? : string) => validTokenPayload);
+    await sampleReview.save();
+    const res = await axios.post(`http://localhost:${testingPort}/v2/removeReview`, { review: sampleReview, token: "non-empty" });
+    expect(res.data.result).toEqual(1);
+    const course = await Classes.findById("newCourse1");
+    expect(course.classDifficulty).toEqual("-");
+    expect(course.classWorkload).toEqual("-");
+    expect(course.classRating).toEqual("-");
+
+    mockVerificationTicket.mockRestore();
+  });
+});

--- a/server/endpoints/AdminActions.ts
+++ b/server/endpoints/AdminActions.ts
@@ -1,11 +1,10 @@
 import { body } from "express-validator";
 
+import { getCrossListOR, getMetricValues } from "common/CourseCard";
 import { Endpoint } from "../endpoints";
 import { Reviews, ReviewDocument, Classes } from "../dbDefs";
-import { verifyToken } from "./Auth";
 import { updateProfessors, findAllSemesters, resetProfessorArray } from "../dbInit"
-import { getCrossListOR, getMetricValues } from "../../common/CourseCard";
-import { getCourseById } from "./utils";
+import { getCourseById, verifyToken } from "./utils";
 
 // The type for a request with an admin action for a review
 interface AdminReviewRequest {

--- a/server/endpoints/AdminActions.ts
+++ b/server/endpoints/AdminActions.ts
@@ -2,12 +2,18 @@ import { body } from "express-validator";
 
 import { Endpoint } from "../endpoints";
 import { Reviews, ReviewDocument, Classes } from "../dbDefs";
-import {verifyToken } from "./Auth";
+import { verifyToken } from "./Auth";
+import { updateProfessors, findAllSemesters } from "../dbInit"
 import { getCrossListOR, getMetricValues } from "../../common/CourseCard";
 
 // The type for a request with an admin action for a review
 interface AdminReviewRequest {
     review: ReviewDocument;
+    token: string;
+}
+
+// The type for a request with an admin action for updating professors info
+interface AdminProfessorsRequest {
     token: string;
 }
 
@@ -115,6 +121,67 @@ export const removeReview: Endpoint<AdminReviewRequest> = {
     } catch (error) {
       // eslint-disable-next-line no-console
       console.log("Error: at 'removeReview' method");
+      // eslint-disable-next-line no-console
+      console.log(error);
+      return 0;
+    }
+  },
+};
+
+/*
+ * Update the database so we have the professors information
+ */
+export const setProfessors: Endpoint<AdminProfessorsRequest> = {
+  guard: [body("token").notEmpty().isAscii()],
+  callback: async (adminProfessorsRequest: AdminProfessorsRequest) => {
+    try {
+      const userIsAdmin = await verifyToken(adminProfessorsRequest.token);
+      if (userIsAdmin) {
+        const semesters = findAllSemesters();
+        console.log("These are the semesters");
+        console.log(semesters);
+        const val = updateProfessors(semesters);
+        if (val) {
+          return val;
+        }
+        console.log("fail at setProfessors");
+        return 0;
+      }
+      return 0;
+    } catch (error) {
+      // eslint-disable-next-line no-console
+      console.log("Error: at 'setProfessors' ");
+      // eslint-disable-next-line no-console
+      console.log(error);
+      return 0;
+    }
+  },
+};
+
+/*
+ * Initializes the classProfessors field in the Classes collection to an empty array so that
+  we have a uniform empty array to fill with updateProfessors
+ */
+export const resetProfessors: Endpoint<AdminProfessorsRequest> = {
+  guard: [body("token").notEmpty().isAscii()],
+  callback: async (adminProfessorsRequest: AdminProfessorsRequest) => {
+    try {
+      const userIsAdmin = await verifyToken(adminProfessorsRequest.token);
+      if (userIsAdmin) {
+        const semesters = findAllSemesters();
+        console.log("These are the semesters");
+        console.log(semesters);
+        const val = resetProfessorArray(semesters);
+        if (val) {
+          return val;
+        }
+        console.log("fail at resetProfessors in method.js");
+        return 0;
+      }
+      return 0;
+    } catch (error) {
+      // eslint-disable-next-line no-console
+      console.log("Error: at 'resetProfessors' method");
       // eslint-disable-next-line no-console
       console.log(error);
       return 0;

--- a/server/endpoints/AdminActions.ts
+++ b/server/endpoints/AdminActions.ts
@@ -1,8 +1,9 @@
 import { body } from "express-validator";
 
 import { Endpoint } from "../endpoints";
-import { Reviews, ReviewDocument } from "../dbDefs";
-import { getCrossListOR } from "../../common/CourseCard";
+import { Reviews, ReviewDocument, Classes } from "../dbDefs";
+import {verifyToken } from "./Auth";
+import { getCrossListOR, getMetricValues } from "../../common/CourseCard";
 
 // The type for a request with an admin action for a review
 interface AdminReviewRequest {
@@ -12,57 +13,108 @@ interface AdminReviewRequest {
 
 // This updates the metrics for an individual class given its Mongo-generated id.
 // Returns 1 if successful, 0 otherwise.
-export const updateCourseMetrics = (courseId, token) => {
-try {
-    const userIsAdmin = await Meteor.call("tokenIsAdmin", token);
+export const updateCourseMetrics = async (courseId, token) => {
+  try {
+    const userIsAdmin = await verifyToken(token);
     if (userIsAdmin) {
-    const course = await Meteor.call("getCourseById", courseId);
-    if (course) {
+      const course = await Meteor.call("getCourseById", courseId);
+      if (course) {
         const crossListOR = getCrossListOR(course);
         const reviews = await Reviews.find({ visible: 1, reported: 0, $or: crossListOR }, {}, { sort: { date: -1 }, limit: 700 }).exec();
         const state = getMetricValues(reviews);
 
         await Classes.updateOne({ _id: courseId },
-        {
+          {
             $set: {
             // If no data is available, getMetricValues returns "-" for metric
-            classDifficulty: (state.diff !== "-" && !isNaN(state.diff) ? Number(state.diff) : null),
-            classRating: (state.rating !== "-" && !isNaN(state.rating) ? Number(state.rating) : null),
-            classWorkload: (state.workload !== "-" && !isNaN(state.workload) ? Number(state.workload) : null),
+              classDifficulty: (state.diff !== "-" && !isNaN(Number(state.diff)) ? Number(state.diff) : null),
+              classRating: (state.rating !== "-" && !isNaN(Number(state.rating)) ? Number(state.rating) : null),
+              classWorkload: (state.workload !== "-" && !isNaN(Number(state.workload)) ? Number(state.workload) : null),
             },
-        });
+          });
         return 1;
+      }
+      return 0;
     }
     return 0;
-    }
-    return 0;
-} catch (error) {
+  } catch (error) {
     // eslint-disable-next-line no-console
     console.log("Error: at 'updateCourseMetrics' method");
     // eslint-disable-next-line no-console
     console.log(error);
     return 0;
-}
+  }
 };
 
 /*
- * Make a review visible
+ * Approve a submitted review and make it visible
  */
 export const makeReviewVisible: Endpoint<AdminReviewRequest> = {
   guard: [body("review").notEmpty(), body("token").notEmpty().isAscii()],
   callback: async (adminReviewRequest: AdminReviewRequest) => {
     try {
       // check: make sure review id is valid and non-malicious
-      const userIsAdmin = ;
+      const userIsAdmin = await verifyToken(adminReviewRequest.token);
       const regex = new RegExp(/^(?=.*[A-Z0-9])/i);
       if (regex.test(adminReviewRequest.review._id) && userIsAdmin) {
         await Reviews.updateOne({ _id: adminReviewRequest.review._id }, { $set: { visible: 1 } });
-        await Meteor.call("updateCourseMetrics", adminReviewRequest.review.class, adminReviewRequest.token);
+        await updateCourseMetrics(adminReviewRequest.review.class, adminReviewRequest.token);
         return 1;
       }
     } catch (error) {
       // eslint-disable-next-line no-console
       console.log("Error: at 'makeVisible' method");
+      // eslint-disable-next-line no-console
+      console.log(error);
+      return 0;
+    }
+  },
+};
+
+/*
+ * "Undo" the reporting of a flagged review and make it visible again
+ */
+export const undoReportReview: Endpoint<AdminReviewRequest> = {
+  guard: [body("review").notEmpty(), body("token").notEmpty().isAscii()],
+  callback: async (adminReviewRequest: AdminReviewRequest) => {
+    try {
+      const userIsAdmin = await verifyToken(adminReviewRequest.token);
+      // check: make sure review id is valid and non-malicious
+      const regex = new RegExp(/^(?=.*[A-Z0-9])/i);
+      if (regex.test(adminReviewRequest.review._id) && userIsAdmin) {
+        await Reviews.updateOne({ _id: adminReviewRequest.review._id }, { $set: { visible: 1, reported: 0 } });
+        return 1;
+      }
+      return 0;
+    } catch (error) {
+      // eslint-disable-next-line no-console
+      console.log("Error: at 'undoReportReview' method");
+      // eslint-disable-next-line no-console
+      console.log(error);
+      return 0;
+    }
+  },
+};
+
+/*
+ * Remove a review, used for both submitted and flagged reviews
+ */
+export const removeReview: Endpoint<AdminReviewRequest> = {
+  guard: [body("review").notEmpty(), body("token").notEmpty().isAscii()],
+  callback: async (adminReviewRequest: AdminReviewRequest) => {
+    try {
+      // check: make sure review id is valid and non-malicious
+      const userIsAdmin = await verifyToken(adminReviewRequest.token);
+      const regex = new RegExp(/^(?=.*[A-Z0-9])/i);
+      if (regex.test(adminReviewRequest.review._id) && userIsAdmin) {
+        await Reviews.remove({ _id: adminReviewRequest.review._id });
+        await updateCourseMetrics(adminReviewRequest.review.class, adminReviewRequest.token);
+        return 1;
+      }
+      return 0;
+    } catch (error) {
+      // eslint-disable-next-line no-console
+      console.log("Error: at 'removeReview' method");
       // eslint-disable-next-line no-console
       console.log(error);
       return 0;

--- a/server/endpoints/AdminActions.ts
+++ b/server/endpoints/AdminActions.ts
@@ -1,0 +1,71 @@
+import { body } from "express-validator";
+
+import { Endpoint } from "../endpoints";
+import { Reviews, ReviewDocument } from "../dbDefs";
+import { getCrossListOR } from "../../common/CourseCard";
+
+// The type for a request with an admin action for a review
+interface AdminReviewRequest {
+    review: ReviewDocument;
+    token: string;
+}
+
+// This updates the metrics for an individual class given its Mongo-generated id.
+// Returns 1 if successful, 0 otherwise.
+export const updateCourseMetrics = (courseId, token) => {
+try {
+    const userIsAdmin = await Meteor.call("tokenIsAdmin", token);
+    if (userIsAdmin) {
+    const course = await Meteor.call("getCourseById", courseId);
+    if (course) {
+        const crossListOR = getCrossListOR(course);
+        const reviews = await Reviews.find({ visible: 1, reported: 0, $or: crossListOR }, {}, { sort: { date: -1 }, limit: 700 }).exec();
+        const state = getMetricValues(reviews);
+
+        await Classes.updateOne({ _id: courseId },
+        {
+            $set: {
+            // If no data is available, getMetricValues returns "-" for metric
+            classDifficulty: (state.diff !== "-" && !isNaN(state.diff) ? Number(state.diff) : null),
+            classRating: (state.rating !== "-" && !isNaN(state.rating) ? Number(state.rating) : null),
+            classWorkload: (state.workload !== "-" && !isNaN(state.workload) ? Number(state.workload) : null),
+            },
+        });
+        return 1;
+    }
+    return 0;
+    }
+    return 0;
+} catch (error) {
+    // eslint-disable-next-line no-console
+    console.log("Error: at 'updateCourseMetrics' method");
+    // eslint-disable-next-line no-console
+    console.log(error);
+    return 0;
+}
+};
+
+/*
+ * Make a review visible
+ */
+export const makeReviewVisible: Endpoint<AdminReviewRequest> = {
+  guard: [body("review").notEmpty(), body("token").notEmpty().isAscii()],
+  callback: async (adminReviewRequest: AdminReviewRequest) => {
+    try {
+      // check: make sure review id is valid and non-malicious
+      const userIsAdmin = ;
+      const regex = new RegExp(/^(?=.*[A-Z0-9])/i);
+      if (regex.test(adminReviewRequest.review._id) && userIsAdmin) {
+        await Reviews.updateOne({ _id: adminReviewRequest.review._id }, { $set: { visible: 1 } });
+        await Meteor.call("updateCourseMetrics", adminReviewRequest.review.class, adminReviewRequest.token);
+        return 1;
+      }
+    } catch (error) {
+      // eslint-disable-next-line no-console
+      console.log("Error: at 'makeVisible' method");
+      // eslint-disable-next-line no-console
+      console.log(error);
+      return 0;
+    }
+  },
+};

--- a/server/endpoints/AdminActions.ts
+++ b/server/endpoints/AdminActions.ts
@@ -3,7 +3,7 @@ import { body } from "express-validator";
 import { getCrossListOR, getMetricValues } from "common/CourseCard";
 import { Endpoint } from "../endpoints";
 import { Reviews, ReviewDocument, Classes } from "../dbDefs";
-import { updateProfessors, findAllSemesters, resetProfessorArray } from "../dbInit"
+import { updateProfessors, findAllSemesters, resetProfessorArray } from "../dbInit";
 import { getCourseById, verifyToken } from "./utils";
 
 // The type for a request with an admin action for a review

--- a/server/endpoints/AdminActions.ts
+++ b/server/endpoints/AdminActions.ts
@@ -80,13 +80,11 @@ export const makeReviewVisible: Endpoint<AdminReviewRequest> = {
  * "Undo" the reporting of a flagged review and make it visible again
  */
 export const undoReportReview: Endpoint<AdminReviewRequest> = {
-  guard: [body("review").notEmpty(), body("token").notEmpty().isAscii()],
+  guard: [body("review").notEmpty(), body("token").notEmpty().isAscii(), body("review._id").isAlphanumeric()],
   callback: async (adminReviewRequest: AdminReviewRequest) => {
     try {
       const userIsAdmin = await verifyToken(adminReviewRequest.token);
-      // check: make sure review id is valid and non-malicious
-      const regex = new RegExp(/^(?=.*[A-Z0-9])/i);
-      if (regex.test(adminReviewRequest.review._id) && userIsAdmin) {
+      if (userIsAdmin) {
         await Reviews.updateOne({ _id: adminReviewRequest.review._id }, { $set: { visible: 1, reported: 0 } });
         return 1;
       }
@@ -105,13 +103,11 @@ export const undoReportReview: Endpoint<AdminReviewRequest> = {
  * Remove a review, used for both submitted and flagged reviews
  */
 export const removeReview: Endpoint<AdminReviewRequest> = {
-  guard: [body("review").notEmpty(), body("token").notEmpty().isAscii()],
+  guard: [body("review").notEmpty(), body("token").notEmpty().isAscii(), body("review._id").isAlphanumeric()],
   callback: async (adminReviewRequest: AdminReviewRequest) => {
     try {
-      // check: make sure review id is valid and non-malicious
       const userIsAdmin = await verifyToken(adminReviewRequest.token);
-      const regex = new RegExp(/^(?=.*[A-Z0-9])/i);
-      if (regex.test(adminReviewRequest.review._id) && userIsAdmin) {
+      if (userIsAdmin) {
         await Reviews.remove({ _id: adminReviewRequest.review._id });
         await updateCourseMetrics(adminReviewRequest.review.class, adminReviewRequest.token);
         return 1;

--- a/server/endpoints/Auth.ts
+++ b/server/endpoints/Auth.ts
@@ -2,7 +2,7 @@ import { body } from "express-validator";
 import { OAuth2Client } from 'google-auth-library';
 import { Endpoint } from "../endpoints";
 import { Students } from "../dbDefs";
-import { verifyToken } from "./utils"; 
+import { verifyToken } from "./utils";
 
 const client = new OAuth2Client("836283700372-msku5vqaolmgvh3q1nvcqm3d6cgiu0v1.apps.googleusercontent.com");
 

--- a/server/endpoints/Auth.ts
+++ b/server/endpoints/Auth.ts
@@ -2,6 +2,7 @@ import { body } from "express-validator";
 import { OAuth2Client } from 'google-auth-library';
 import { Endpoint } from "../endpoints";
 import { Students } from "../dbDefs";
+import { verifyToken } from "./utils"; 
 
 const client = new OAuth2Client("836283700372-msku5vqaolmgvh3q1nvcqm3d6cgiu0v1.apps.googleusercontent.com");
 
@@ -53,29 +54,6 @@ export const getUserByNetId = async (netId: string) => {
     // eslint-disable-next-line no-console
     console.log(error);
     return null;
-  }
-};
-
-/**/
-export const verifyToken = async (token: string) => {
-  try {
-    const regex = new RegExp(/^(?=.*[A-Z0-9])/i);
-    if (regex.test(token)) {
-      const ticket = await getVerificationTicket(token);
-      if (ticket && ticket.email) {
-        const user = await getUserByNetId(ticket.email.replace('@cornell.edu', ''));
-        if (user) {
-          return user.privilege === 'admin';
-        }
-      }
-    }
-    return false;
-  } catch (error) {
-    // eslint-disable-next-line no-console
-    console.log("Error: at 'verufyToken' method");
-    // eslint-disable-next-line no-console
-    console.log(error);
-    return false;
   }
 };
 

--- a/server/endpoints/utils.ts
+++ b/server/endpoints/utils.ts
@@ -1,5 +1,6 @@
 import { CourseId } from "./Review";
 import { Classes } from "../dbDefs";
+import { getUserByNetId, getVerificationTicket } from "./Auth";
 
 // eslint-disable-next-line import/prefer-default-export
 export const getCourseById = async (courseId: CourseId) => {
@@ -16,5 +17,27 @@ export const getCourseById = async (courseId: CourseId) => {
     // eslint-disable-next-line no-console
     console.log(error);
     return { error: "Internal Server Error" };
+  }
+};
+
+export const verifyToken = async (token: string) => {
+  try {
+    const regex = new RegExp(/^(?=.*[A-Z0-9])/i);
+    if (regex.test(token)) {
+      const ticket = await getVerificationTicket(token);
+      if (ticket && ticket.email) {
+        const user = await getUserByNetId(ticket.email.replace('@cornell.edu', ''));
+        if (user) {
+          return user.privilege === 'admin';
+        }
+      }
+    }
+    return false;
+  } catch (error) {
+    // eslint-disable-next-line no-console
+    console.log("Error: at 'verufyToken' method");
+    // eslint-disable-next-line no-console
+    console.log(error);
+    return false;
   }
 };


### PR DESCRIPTION
### Summary <!-- Required -->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Itemize bug fixes, new features, and other changes -->
<!-- Feel free to break this into sub-sections, i.e. features, fixes, etc. -->
<!-- Some examples are shown below. -->

This pull request creates endpoints for the 5 Meteor methods that require admin authentication to carry out that are not stats dashboard related. It also adds unit tests where applicable and refactors Auth.ts to account for the new utils.ts folder.

### Test Plan <!-- Required -->

Added unit tests in AdminActions.test.ts

### Notes <!-- Optional -->

Unit tests weren't added for the two professor functions because their functionality falls under behavior that should be tested in dbInit.test.ts. There aren't any unit tests for the underlying dbInit functions used already. I don't think there's much use in unit tests for those endpoints/functions, but I wanted to note in case it raised concerns.

