### PR TITLE
Odds and Ends, and wrapping up new public API

### DIFF
--- a/server/endpoints.ts
+++ b/server/endpoints.ts
@@ -1,6 +1,6 @@
 import express from "express";
 import { validationResult, ValidationChain } from "express-validator";
-import { getReviewsByCourseId, getCourseById } from "./endpoints/Review";
+import { getReviewsByCourseId, getCourseById, getCourseByInfo } from "./endpoints/Review";
 import { tokenIsAdmin } from "./endpoints/Auth";
 import { getClassesByQuery, getSubjectsByQuery, getProfessorsByQuery } from "./endpoints/Search";
 
@@ -25,6 +25,7 @@ export function configure(app: express.Application) {
   register(app, "tokenIsAdmin", tokenIsAdmin);
   register(app, "getSubjectsByQuery", getSubjectsByQuery);
   register(app, "getProfessorsByQuery", getProfessorsByQuery);
+  register(app, "getCourseByInfo", getCourseByInfo);
 }
 
 function register<T>(app: express.Application, name: string, endpoint: Endpoint<T>) {

--- a/server/endpoints/Review.test.ts
+++ b/server/endpoints/Review.test.ts
@@ -100,8 +100,28 @@ describe('tests', () => {
     expect(res.data.result.classTitle).toBe("Object-Oriented Programming and Data Structures");
   });
 
+  it('getCourseByInfo - getting cs2110', async () => {
+    const res = await axios.post(`http://localhost:${testingPort}/v2/getCourseByInfo`, { subject: "cs", number: "2110" });
+    expect(res.data.result._id).toBe("oH37S3mJ4eAsktypy");
+    expect(res.data.result.classTitle).toBe("Object-Oriented Programming and Data Structures");
+  });
+
+  it('getCourseByInfo - demonstrate regex irrelevance', async () => {
+    // Will not accept non-numeric:
+    const res1 = await axios.post(`http://localhost:${testingPort}/v2/getCourseByInfo`, { subject: "Vainamoinen", number: "ab2187c" }).catch((e) => e);
+    expect(res1.message).toBe("Request failed with status code 400");
+
+    // Will not accept non-ascii:
+    const res2 = await axios.post(`http://localhost:${testingPort}/v2/getCourseByInfo`, { subject: "向岛维纳默宁", number: "1234" }).catch((e) => e);
+    expect(res2.message).toBe("Request failed with status code 400");
+
+    // Both also does not work:
+    const res3 = await axios.post(`http://localhost:${testingPort}/v2/getCourseByInfo`, { subject: "向岛维纳默宁", number: "ab2187c" }).catch((e) => e);
+    expect(res3.message).toBe("Request failed with status code 400");
+  });
+
   it("getReviewsByCourseId - getting review for a class that does not exist", async () => {
     const res = await axios.post(`http://localhost:${testingPort}/v2/getReviewsByCourseId`, { courseId: "ert" });
-    expect(res.data.result).toEqual({ error: 'Invalid course id' });
+    expect(res.data.result).toEqual({ error: 'Malformed Query' });
   });
 });

--- a/server/endpoints/Review.ts
+++ b/server/endpoints/Review.ts
@@ -1,38 +1,61 @@
 import { body } from "express-validator";
 import { getCrossListOR } from "common/CourseCard";
 import { Endpoint } from "../endpoints";
-import { Reviews } from "../dbDefs";
+import { Classes, Reviews } from "../dbDefs";
 import { getCourseById as getCourseByIdCallback } from "./utils";
 
-export interface CourseId {
+// The type of a query with a courseId
+export interface CourseIdQuery {
   courseId: string;
+}
+
+// The type of a query with a course number and subject
+interface ClassByInfoQuery {
+  subject: string;
+  number: string;
 }
 
 /**
  * Get a course with this course_id from the Classes collection
  */
-export const getCourseById: Endpoint<CourseId> = {
+export const getCourseById: Endpoint<CourseIdQuery> = {
   guard: [body("courseId").notEmpty().isAscii()],
   callback: getCourseByIdCallback,
+};
+
+/*
+ * Searches the database for a course matching the subject and course number. Used in class info retrieval.
+ * See also: getCourseById above
+ */
+export const getCourseByInfo: Endpoint<ClassByInfoQuery> = {
+  guard: [body("number").notEmpty().isNumeric(), body("subject").notEmpty().isAscii()],
+  callback: async (query: ClassByInfoQuery) => {
+    try {
+      return await Classes.findOne({ classSub: query.subject, classNum: query.number }).exec();
+    } catch (error) {
+      // eslint-disable-next-line no-console
+      console.log("Error: at 'getCourseByInfo' endpoint");
+      // eslint-disable-next-line no-console
+      console.log(error);
+      return { error: "Internal Server Error" };
+    }
+  },
 };
 
 /**
  * Get list of review objects for given class from class _id
  */
-export const getReviewsByCourseId: Endpoint<CourseId> = {
+export const getReviewsByCourseId: Endpoint<CourseIdQuery> = {
   guard: [body("courseId").notEmpty().isAscii()],
-  callback: async (courseId: CourseId) => {
+  callback: async (courseId: CourseIdQuery) => {
     try {
-      const regex = new RegExp(/^(?=.*[A-Z])/i);
-      if (regex.test(courseId.courseId)) {
-        const course = await getCourseByIdCallback(courseId);
-        if (course) {
-          const crossListOR = getCrossListOR(course);
-          const reviews = await Reviews.find({ visible: 1, reported: 0, $or: crossListOR }, {}, { sort: { date: -1 }, limit: 700 }).exec();
-          return reviews;
-        }
-        return { error: "Invalid course id" };
+      const course = await getCourseByIdCallback(courseId);
+      if (course) {
+        const crossListOR = getCrossListOR(course);
+        const reviews = await Reviews.find({ visible: 1, reported: 0, $or: crossListOR }, {}, { sort: { date: -1 }, limit: 700 }).exec();
+        return reviews;
       }
+
       return { error: "Malformed Query" };
     } catch (error) {
       // eslint-disable-next-line no-console

--- a/server/endpoints/Search.test.ts
+++ b/server/endpoints/Search.test.ts
@@ -95,7 +95,7 @@ beforeAll(async () => {
     major: "MORK",
   });
 
-  prof1.save();
+  await prof1.save();
 
   const prof2 = new Professors({
     _id: "prof 2",
@@ -104,7 +104,7 @@ beforeAll(async () => {
     major: "FEDN",
   });
 
-  prof2.save();
+  await prof2.save();
 
   // Set up a mock version of the v2 endpoints to test against
   const app = express();

--- a/server/endpoints/Search.ts
+++ b/server/endpoints/Search.ts
@@ -87,11 +87,7 @@ export const getSubjectsByQuery: Endpoint<Search> = {
   guard: [body("query").notEmpty().isAscii()],
   callback: async (search: Search) => {
     try {
-      const regex = new RegExp(/^(?=.*[A-Z0-9])/i);
-      if (regex.test(search.query)) {
-        return await Subjects.find({ $text: { $search: search.query } }, { score: { $meta: "textScore" } }, { sort: { score: { $meta: "textScore" } } }).exec();
-      }
-      return { error: "Malformed Query" };
+      return await Subjects.find({ $text: { $search: search.query } }, { score: { $meta: "textScore" } }, { sort: { score: { $meta: "textScore" } } }).exec();
     } catch (error) {
       // eslint-disable-next-line no-console
       console.log("Error: at 'getSubjectsByQuery' endpoint");
@@ -107,13 +103,9 @@ export const getSubjectsByQuery: Endpoint<Search> = {
  */
 export const getProfessorsByQuery: Endpoint<Search> = {
   guard: [body("query").notEmpty().isAscii()],
-  callback: async (seach: Search) => {
+  callback: async (search: Search) => {
     try {
-      const regex = new RegExp(/^(?=.*[A-Z0-9])/i);
-      if (regex.test(seach.query)) {
-        return await Professors.find({ $text: { $search: seach.query } }, { score: { $meta: "textScore" } }, { sort: { score: { $meta: "textScore" } } }).exec();
-      }
-      return { error: "Malformed Query" };
+      return await Professors.find({ $text: { $search: search.query } }, { score: { $meta: "textScore" } }, { sort: { score: { $meta: "textScore" } } }).exec();
     } catch (error) {
       // eslint-disable-next-line no-console
       console.log("Error: at 'getProfessorsByQuery' endpoint");

--- a/server/endpoints/utils.ts
+++ b/server/endpoints/utils.ts
@@ -1,8 +1,8 @@
-import { CourseId } from "./Review";
+import { CourseIdQuery } from "./Review";
 import { Classes } from "../dbDefs";
 
 // eslint-disable-next-line import/prefer-default-export
-export const getCourseById = async (courseId: CourseId) => {
+export const getCourseById = async (courseId: CourseIdQuery) => {
   try {
     // check: make sure course id is valid and non-malicious
     const regex = new RegExp(/^(?=.*[A-Z0-9])/i);


### PR DESCRIPTION
### Summary <!-- Required -->

This PR is another part of the long road to severing our dependence on the Meteor shim. It also tries to get rid of some of the bad code that is infiltrating our codebase as holdovers from methods.ts.

In particular, it added another method which (as far as I was able to tell) is the final one used for public accesses (i.e. not cornell student submission dependent). Let me know if there was one I missed.

Additionally, this PR removes the obsessive regex checking in some of the backend method. It adds nothing that is not provided in a better way by the guard pattern and express-validator. See the test in Reviews.test.ts which show that these features really do work as intended. Going forward, I think it makes sense to remove these regex checks if they can be replaced by equivalent code in the guard.

### Test Plan <!-- Required -->

See the additional unit tests in Reviews.test.ts.

### Notes <!-- Optional -->

 Also see some awaits in Search.test.ts which were missing, and theoretically might have caused problems down the line. I also refractored a name for an interface.

### Breaking Changes 

None yet, as per usual.