### PR TITLE
Client side uses search express

### DIFF
--- a/client/src/ui/Results.jsx
+++ b/client/src/ui/Results.jsx
@@ -4,6 +4,7 @@ import "./css/Results.css"; // css files
 import Navbar from './Navbar';
 import ResultsDisplay from './ResultsDisplay.jsx';
 import PropTypes from "prop-types";
+import axios from 'axios';
 
 /*
   Results Component.
@@ -65,32 +66,24 @@ export class Results extends Component {
       if(userQuery && userQuery.split(" ").length === 1){
         userQuery = userQuery.match(/[a-z]+|[^a-z]+/gi).join(" ");
       }
-      Meteor.call("getCoursesByKeyword", userQuery, (err, courseList) => {
-        if (!err && courseList.length !== 0) {
+      axios.post(`/v2/getClassesByQuery`, { query: userQuery }).then(response => {
+        const queryCourseList = response.data.result; 
+        if (queryCourseList.length !== 0) {
           // Save the Class object that matches the request
           this.setState({
-            courseList: courseList,
+            courseList: queryCourseList,
             loading: false
           });
         }
         else {
-          Meteor.call("getClassesByQuery", userQuery, (err, queryCourseList) => {
-            if (!err && queryCourseList.length !== 0) {
-              // Save the Class object that matches the request
-              this.setState({
-                courseList: queryCourseList,
-                loading: false
-              });
-            }
-            else {
               this.setState({
                 courseList: [],
                 loading: false
               });
             }
-          })
         }
-      });
+      )
+      .catch(e => console.log("Getting courses failed!"));
     }
   }
 

--- a/client/src/ui/SearchBar.jsx
+++ b/client/src/ui/SearchBar.jsx
@@ -86,21 +86,12 @@ export default class SearchBar extends Component {
           });
         }
         else {
-          Meteor.call("getClassesByQuery", this.state.query, (err, queryCourseList) => {
-            if (!err && queryCourseList && queryCourseList.length !== 0) {
-              // Save the list of Class objects that matches the request
-              this.setState({
-                allCourses: queryCourseList
-              });
-            }
-            else {
               this.setState({
                 allCourses: []
               });
             }
-          })
         }
-      })
+      )
       .catch(e => console.log("Getting coureses failed!"));
 
       axios.post(`/v2/getSubjectsByQuery`, { query: this.state.query }).then(response => {
@@ -117,20 +108,6 @@ export default class SearchBar extends Component {
           });
         }
       }).catch(e => console.log("Getting subjects failed!"));
-
-      // Meteor.call("getProfessorsByName", this.state.query, (err, subjectList) => {
-      //   if (!err && subjectList && subjectList.length !== 0) {
-      //     // Save the list of Subject objects that matches the request
-      //     this.setState({
-      //       allProfessors: subjectList
-      //     });
-      //   }
-      //   else {
-      //     this.setState({
-      //       allProfessors: []
-      //     });
-      //   }
-      // });
 
       axios.post(`/v2/getProfessorsByQuery`, { query: this.state.query }).then(response => {
         const professorList = response.data.result;

--- a/client/src/ui/SearchBar.jsx
+++ b/client/src/ui/SearchBar.jsx
@@ -92,7 +92,7 @@ export default class SearchBar extends Component {
             }
         }
       )
-      .catch(e => console.log("Getting coureses failed!"));
+      .catch(e => console.log("Getting courses failed!"));
 
       axios.post(`/v2/getSubjectsByQuery`, { query: this.state.query }).then(response => {
         const subjectList = response.data.result;

--- a/client/src/ui/SearchBar.jsx
+++ b/client/src/ui/SearchBar.jsx
@@ -7,6 +7,7 @@ import Subject from './Subject';
 import Professor from './Professor';
 import "./css/SearchBar.css";
 import { Redirect } from 'react-router';
+import axios from "axios";
 
 /*
   SearchBar Component.
@@ -76,11 +77,12 @@ export default class SearchBar extends Component {
 
   componentDidUpdate(prevProps, prevState) {
     if (this.state.query.toLowerCase() !== prevState.query.toLowerCase() || this.props !== prevProps) {
-      Meteor.call("getCoursesByKeyword", this.state.query, (err, courseList) => {
-        if (!err && courseList && courseList.length !== 0) {
-          // Save the list of Class objects that matches the request
+      axios.post(`/v2/getClassesByQuery`, { query: this.state.query }).then(response => {
+        const queryCourseList = response.data.result; 
+        if (queryCourseList.length !== 0) {
+          // Save the Class object that matches the request
           this.setState({
-            allCourses: courseList
+            allCourses: queryCourseList
           });
         }
         else {
@@ -98,10 +100,12 @@ export default class SearchBar extends Component {
             }
           })
         }
-      });
+      })
+      .catch(e => console.log("Getting coureses failed!"));
 
-      Meteor.call("getSubjectsByKeyword", this.state.query, (err, subjectList) => {
-        if (!err && subjectList && subjectList.length !== 0) {
+      axios.post(`/v2/getSubjectsByQuery`, { query: this.state.query }).then(response => {
+        const subjectList = response.data.result;
+        if (subjectList && subjectList.length !== 0) {
           // Save the list of Subject objects that matches the request
           this.setState({
             allSubjects: subjectList
@@ -112,13 +116,28 @@ export default class SearchBar extends Component {
             allSubjects: []
           });
         }
-      });
+      }).catch(e => console.log("Getting subjects failed!"));
 
-      Meteor.call("getProfessorsByName", this.state.query, (err, subjectList) => {
-        if (!err && subjectList && subjectList.length !== 0) {
+      // Meteor.call("getProfessorsByName", this.state.query, (err, subjectList) => {
+      //   if (!err && subjectList && subjectList.length !== 0) {
+      //     // Save the list of Subject objects that matches the request
+      //     this.setState({
+      //       allProfessors: subjectList
+      //     });
+      //   }
+      //   else {
+      //     this.setState({
+      //       allProfessors: []
+      //     });
+      //   }
+      // });
+
+      axios.post(`/v2/getProfessorsByQuery`, { query: this.state.query }).then(response => {
+        const professorList = response.data.result;
+        if (professorList && professorList.length !== 0) {
           // Save the list of Subject objects that matches the request
           this.setState({
-            allProfessors: subjectList
+            allProfessors: professorList
           });
         }
         else {
@@ -126,7 +145,8 @@ export default class SearchBar extends Component {
             allProfessors: []
           });
         }
-      });
+      }).catch(e => console.log("Getting subjects failed!"));
+
     }
   }
 

--- a/server/endpoints/AdminActions.test.ts
+++ b/server/endpoints/AdminActions.test.ts
@@ -12,7 +12,7 @@ let mongoServer: MongoMemoryServer;
 let serverCloseHandle;
 const mockVerification = jest.spyOn(Utils, 'verifyToken').mockImplementation(async (token? : string) => true);
 
-const testingPort = 37728;
+const testingPort = 47728;
 
 const sampleReviewId = "sampleReview";
 const reviewToUndoReportId = "reviewToUndoReport";

--- a/server/endpoints/Search.ts
+++ b/server/endpoints/Search.ts
@@ -136,7 +136,7 @@ export const regexClassesSearch = async (searchString) => {
  * Query for classes using a query
  */
 export const getClassesByQuery: Endpoint<Search> = {
-  guard: [body("query").notEmpty().isAscii()],
+  guard: [body("query").notEmpty().isAscii(), body("query").whitelist("^[A-Za-z0-9 ]+$")],
   callback: async (search: Search) => {
     try {
       const classes = await Classes.find({ $text: { $search: search.query } }, { score: { $meta: "textScore" } }, { sort: { score: { $meta: "textScore" } } }).exec();

--- a/server/endpoints/Search.ts
+++ b/server/endpoints/Search.ts
@@ -136,7 +136,7 @@ export const regexClassesSearch = async (searchString) => {
  * Query for classes using a query
  */
 export const getClassesByQuery: Endpoint<Search> = {
-  guard: [body("query").notEmpty().isAscii(), body("query").whitelist("^[A-Za-z0-9 ]+$")],
+  guard: [body("query").notEmpty().isAscii().whitelist("^[A-Za-z0-9 ]+$")],
   callback: async (search: Search) => {
     try {
       const classes = await Classes.find({ $text: { $search: search.query } }, { score: { $meta: "textScore" } }, { sort: { score: { $meta: "textScore" } } }).exec();

--- a/server/endpoints/Search.ts
+++ b/server/endpoints/Search.ts
@@ -136,14 +136,14 @@ export const regexClassesSearch = async (searchString) => {
  * Query for classes using a query
  */
 export const getClassesByQuery: Endpoint<Search> = {
-  guard: [body("query").notEmpty().isAscii(), body("query").notEmpty().isAlphanumeric()],
+  guard: [body("query").notEmpty().isAscii()],
   callback: async (search: Search) => {
     try {
       const classes = await Classes.find({ $text: { $search: search.query } }, { score: { $meta: "textScore" } }, { sort: { score: { $meta: "textScore" } } }).exec();
       if (classes && classes.length > 0) {
         return classes.sort(courseSort(search.query));
       }
-      return regexClassesSearch(search.query);
+      return await regexClassesSearch(search.query);
     } catch (error) {
       // eslint-disable-next-line no-console
       console.log("Error: at 'getClassesByQuery' endpoint");

--- a/server/methods.ts
+++ b/server/methods.ts
@@ -554,68 +554,6 @@ Meteor.methods({
     }
   },
 
-  async getClassesByQuery(searchString: string) {
-    console.log(`getClassesByQuery triggered: ${searchString}`);
-    try {
-      if (searchString !== undefined && searchString !== '') {
-        // check if first digit is a number. Catches searchs like "1100"
-        // if so, search only through the course numbers and return classes ordered by full name
-        const indexFirstDigit = searchString.search(/\d/);
-        if (indexFirstDigit === 0) {
-          // console.log("only numbers")
-          return Classes.find(
-            { classNum: { $regex: `.*${searchString}.*`, $options: '-i' } },
-            {},
-            { sort: { classFull: 1 }, limit: 200, reactive: false },
-          ).exec().then((classes) => classes.sort(courseSort(searchString)));
-        }
-
-        // check if searchString is a subject, if so return only classes with this subject. Catches searches like "CS"
-        if (await isSubShorthand(searchString)) {
-          return Classes.find({ classSub: searchString }, {}, { sort: { classFull: 1 }, limit: 200, reactive: false }).exec();
-        }
-        // check if text before space is subject, if so search only classes with this subject.
-        // Speeds up searches like "CS 1110"
-        const indexFirstSpace = searchString.search(' ');
-        if (indexFirstSpace !== -1) {
-          const strBeforeSpace = searchString.substring(0, indexFirstSpace);
-          const strAfterSpace = searchString.substring(indexFirstSpace + 1);
-          if (await isSubShorthand(strBeforeSpace)) {
-            // console.log("matches subject with space: " + strBeforeSpace)
-            return await searchWithinSubject(strBeforeSpace, strAfterSpace);
-          }
-        }
-
-        // check if text is subject followed by course number (no space)
-        // if so search only classes with this subject.
-        // Speeds up searches like "CS1110"
-        if (indexFirstDigit !== -1) {
-          const strBeforeDigit = searchString.substring(0, indexFirstDigit);
-          const strAfterDigit = searchString.substring(indexFirstDigit);
-          if (await isSubShorthand(strBeforeDigit)) {
-            // console.log("matches subject with digit: " + String(strBeforeDigit))
-            return await searchWithinSubject(strBeforeDigit, strAfterDigit);
-          }
-        }
-
-        // last resort, search everything
-        // console.log("nothing matches");
-        return Classes.find(
-          { classFull: { $regex: `.*${searchString}.*`, $options: '-i' } },
-          {}, { sort: { classFull: 1 }, limit: 200, reactive: false },
-        ).exec();
-      }
-      // console.log("no search");
-      return Classes.find({}, {}, { sort: { classFull: 1 }, limit: 200, reactive: false }).exec();
-    } catch (error) {
-      // eslint-disable-next-line no-console
-      console.log("Error: at 'getClassesByQuery' method");
-      // eslint-disable-next-line no-console
-      console.log(error);
-      return null;
-    }
-  },
-
   // Get a course with this course_id from the Classes collection in the local database.
   async getCourseById(courseId) {
     try {
@@ -648,59 +586,6 @@ Meteor.methods({
     } catch (error) {
       // eslint-disable-next-line no-console
       console.log("Error: at 'getCourseByInfo' method");
-      // eslint-disable-next-line no-console
-      console.log(error);
-      return null;
-    }
-  },
-
-  // Searches the database on Classes's text index and returns matching courses
-  async getCoursesByKeyword(keyword: string) {
-    console.log(`getCoursesByKeyword triggered: ${keyword}`);
-    try {
-      const regex = new RegExp(/^(?=.*[A-Z0-9])/i);
-      if (regex.test(keyword)) {
-        return (await Classes.find({ $text: { $search: keyword } }, { score: { $meta: "textScore" } }, { sort: { score: { $meta: "textScore" } } }).exec())
-          .sort(courseSort(keyword));
-      }
-      return null;
-    } catch (error) {
-      // eslint-disable-next-line no-console
-      console.log("Error: at 'getCoursesByKeyword' method");
-      // eslint-disable-next-line no-console
-      console.log(error);
-      return null;
-    }
-  },
-
-  // Searches the database on Subjects's text index and returns matching subjects (which we're equating to majors)
-  async getSubjectsByKeyword(keyword: string) {
-    try {
-      const regex = new RegExp(/^(?=.*[A-Z0-9])/i);
-      if (regex.test(keyword)) {
-        return await Subjects.find({ $text: { $search: keyword } }, { score: { $meta: "textScore" } }, { sort: { score: { $meta: "textScore" } } }).exec();
-      }
-      return null;
-    } catch (error) {
-      // eslint-disable-next-line no-console
-      console.log("Error: at 'getSubjectsByKeyword' method");
-      // eslint-disable-next-line no-console
-      console.log(error);
-      return null;
-    }
-  },
-
-  // Searches the database on Professors's text index and returns matching professors
-  async getProfessorsByName(name: string) {
-    try {
-      const regex = new RegExp(/^(?=.*[A-Z0-9])/i);
-      if (regex.test(name)) {
-        return await Professors.find({ $text: { $search: name } }, { score: { $meta: "textScore" } }, { sort: { score: { $meta: "textScore" } } }).exec();
-      }
-      return null;
-    } catch (error) {
-      // eslint-disable-next-line no-console
-      console.log("Error: at 'getProfessorsByName' method");
       // eslint-disable-next-line no-console
       console.log(error);
       return null;


### PR DESCRIPTION
### Summary <!-- Required -->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Itemize bug fixes, new features, and other changes -->
<!-- Feel free to break this into sub-sections, i.e. features, fixes, etc. -->
<!-- Some examples are shown below. -->

This pull request replaces Meteor calls for getting classes by keyword/query on the front end. It also moves the getClassesByQuery Meteor method that uses regular expressions to the getClassesByQuery endpoint and moved its regular expression check to the endpoint's guard. 

### Test Plan <!-- Required -->

- checked existing unit tests worked for getClassesByQuery endpoint
- Tested searching from home page, results page, course page

### Notes <!-- Optional -->

We should do thorough testing on the dev site again since searching is so essential to using the site.

### Breaking Changes  <!-- Optional -->

N/A

