### PR TITLE
Fix subject and professor component names

### DIFF
--- a/client/src/ui/ProfessorResult.tsx
+++ b/client/src/ui/ProfessorResult.tsx
@@ -1,17 +1,17 @@
 import React, { Component} from 'react';
 import "./css/Course.css";
 import { Redirect } from 'react-router';
-import { Subject } from 'common';
+import { Professor } from 'common';
 
 /*
-  Subject Component.
+  Professor Component.
 
-  Simple styling component that represents a single subject (an a element).
-  Used to list subject in the results of a search in SearchBar.
+  Simple styling component that represents a single professor (an a element).
+  Used to list professor in the results of a search in SearchBar.
 */
 
 type Props = {
-  info: Subject;
+  professor: Professor;
   query?: string; //optional
   active: boolean;
   enter: 1 | 0;
@@ -19,14 +19,15 @@ type Props = {
   key: string;
 };
 
-export default class Course extends Component<Props> {
+export default class ProfessorResult extends Component<Props> {
   render() {
     // generate full human-readable name of class
-    const subjectInfo = this.props.info;
-    let text = subjectInfo.subFull;
+    const professorObject = this.props.professor;
+    let text = professorObject.fullName;
+    let professorURL = professorObject.fullName.split(" ").join("+")
     //if the element is highlighted and the enter key was pressed, create a Redirect component to go to the class
     if(this.props.active && this.props.enter === 1){
-       return <Redirect push to={`/results/major/${subjectInfo.subShort.toUpperCase()}`}></Redirect>
+       return <Redirect push to={`/results/professor/${professorURL}`}></Redirect>
       }
 
     //return classname as a list element
@@ -35,9 +36,9 @@ export default class Course extends Component<Props> {
     //if the mouse is in the list element, highlighting by arrow key stops and follow the mouse hovers
     //if the mouse leaves the list element, highlighting by arrow key continues but from the first element
       <a className={this.props.active && this.props.mouse !== 1 ? 'active-class resultbutton' : 'resultbutton'}
-          href={`/results/major/${subjectInfo.subShort.toUpperCase()}`}>
-        <p className="result-label-subject">
-          Major
+          href={`/results/professor/${professorURL}`}>
+        <p className="result-label-professor">
+          Professor
         </p>
         <p className="result-text">{text}</p>
       </a>

--- a/client/src/ui/SearchBar.jsx
+++ b/client/src/ui/SearchBar.jsx
@@ -3,8 +3,8 @@ import PropTypes from 'prop-types';
 import { Session } from '../meteor-session';
 import { Meteor } from '../meteor-shim';
 import Course from './Course';
-import Subject from './Subject';
-import Professor from './Professor';
+import SubjectResult from './SubjectResult';
+import ProfessorResult from './ProfessorResult';
 import "./css/SearchBar.css";
 import { Redirect } from 'react-router';
 import axios from "axios";
@@ -276,7 +276,7 @@ export default class SearchBar extends Component {
 
       let subjectList = this.state.allSubjects.slice(0, 3).map((subject, i) => (
         //create a new class "button" that will set the selected class to this class when it is clicked.
-        <Subject key={subject._id} info={subject} query={this.state.query}
+        <SubjectResult key={subject._id} info={subject} query={this.state.query}
           active={this.state.index === (i + 1 /* plus 1 because of exact search */)}
           enter={this.state.enter} mouse={this.state.mouse} />
         //the prop "active" will pass through a bool indicating if the index affected through arrow movement is equal to
@@ -295,7 +295,7 @@ export default class SearchBar extends Component {
       // Generate list of matching professors and add to results list
       let professorList = this.state.allProfessors.slice(0, 3).map((professor, i) => (
         //create a new class "button" that will set the selected class to this class when it is clicked.
-        <Professor key={professor._id} professor={professor} query={this.state.query}
+        <ProfessorResult key={professor._id} professor={professor} query={this.state.query}
           active={this.state.index === (i + subjectList.length + 1 /* plus 1 because of exact search */)}
           enter={this.state.enter} mouse={this.state.mouse} />
         //the prop "active" will pass through a bool indicating if the index affected through arrow movement is equal to

--- a/client/src/ui/SubjectResult.tsx
+++ b/client/src/ui/SubjectResult.tsx
@@ -1,17 +1,17 @@
 import React, { Component} from 'react';
 import "./css/Course.css";
 import { Redirect } from 'react-router';
-import { Professor } from 'common';
+import { Subject } from 'common';
 
 /*
-  Professor Component.
+  Subject Component.
 
-  Simple styling component that represents a single professor (an a element).
-  Used to list professor in the results of a search in SearchBar.
+  Simple styling component that represents a single subject (an a element).
+  Used to list subject in the results of a search in SearchBar.
 */
 
 type Props = {
-  professor: Professor;
+  info: Subject;
   query?: string; //optional
   active: boolean;
   enter: 1 | 0;
@@ -19,15 +19,14 @@ type Props = {
   key: string;
 };
 
-export default class Course extends Component<Props> {
+export default class SubjectResult extends Component<Props> {
   render() {
     // generate full human-readable name of class
-    const professorObject = this.props.professor;
-    let text = professorObject.fullName;
-    let professorURL = professorObject.fullName.split(" ").join("+")
+    const subjectInfo = this.props.info;
+    let text = subjectInfo.subFull;
     //if the element is highlighted and the enter key was pressed, create a Redirect component to go to the class
     if(this.props.active && this.props.enter === 1){
-       return <Redirect push to={`/results/professor/${professorURL}`}></Redirect>
+       return <Redirect push to={`/results/major/${subjectInfo.subShort.toUpperCase()}`}></Redirect>
       }
 
     //return classname as a list element
@@ -36,9 +35,9 @@ export default class Course extends Component<Props> {
     //if the mouse is in the list element, highlighting by arrow key stops and follow the mouse hovers
     //if the mouse leaves the list element, highlighting by arrow key continues but from the first element
       <a className={this.props.active && this.props.mouse !== 1 ? 'active-class resultbutton' : 'resultbutton'}
-          href={`/results/professor/${professorURL}`}>
-        <p className="result-label-professor">
-          Professor
+          href={`/results/major/${subjectInfo.subShort.toUpperCase()}`}>
+        <p className="result-label-subject">
+          Major
         </p>
         <p className="result-text">{text}</p>
       </a>


### PR DESCRIPTION
### Summary <!-- Required -->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Itemize bug fixes, new features, and other changes -->
<!-- Feel free to break this into sub-sections, i.e. features, fixes, etc. -->
<!-- Some examples are shown below. -->

This pull request is a code clean up that renames the subject and professor components, which had previously been named 'Course' in their tsx files and fixes the accompanying imports.

### Test Plan <!-- Required -->

Tested searching by course, professor, and major.

### Notes <!-- Optional -->
N/A
