### PR TITLE
Make function name in Statistics.tsx clearer

### DIFF
--- a/client/src/ui/Statistics.tsx
+++ b/client/src/ui/Statistics.tsx
@@ -40,7 +40,7 @@ export default class Statistics extends Component<Props, State>{
   }
 
   componentDidMount() {
-    this.howManyEachClass();
+    this.getHowManyEachClass();
     this.howManyReviewsEachClass();
     this.totalReviews();
     this.getChartData();
@@ -94,7 +94,7 @@ export default class Statistics extends Component<Props, State>{
     return strRet;
   }
 
-  howManyEachClass() {
+  getHowManyEachClass() {
     Meteor.call('howManyEachClass', Session.get("token"), (error: any, result: any) => {
       if (error === null) {
         result.sort((rev1: any, rev2: any) => (rev1.total > rev2.total) ? -1 : 1);


### PR DESCRIPTION
### Summary <!-- Required -->

Another 🧼 Code clean up day PR, this renames a function name in Statistics.tsx to be getHowManyEachClass from howManyEachClass. This improves clarity because there was also a member of state in this component named howManyEachClass.

### Test Plan <!-- Required -->

Open admin page and waited for it to load as expected.

### Notes <!-- Optional -->

🧼 squeaky clean code

### Breaking Changes  <!-- Optional -->

N/A
