### PR TITLE
Update all course metrics et. al.

### DIFF
--- a/server/endpoints.ts
+++ b/server/endpoints.ts
@@ -4,7 +4,7 @@ import { totalReviews, howManyReviewsEachClass, howManyEachClass, topSubjects, g
 import { getReviewsByCourseId, getCourseById, insertReview, insertUser, getCourseByInfo, incrementLike, decrementLike } from "./endpoints/Review";
 import { tokenIsAdmin } from "./endpoints/Auth";
 import { getClassesByQuery, getSubjectsByQuery, getProfessorsByQuery } from "./endpoints/Search";
-import { makeReviewVisible, undoReportReview, removeReview } from "./endpoints/AdminActions";
+import { updateAllCourseMetrics, makeReviewVisible, undoReportReview, removeReview } from "./endpoints/AdminActions";
 
 export interface Context {
   ip: string;
@@ -46,6 +46,7 @@ export function configure(app: express.Application) {
   register(app, "getReviewsOverTimeTop15", getReviewsOverTimeTop15);
   register(app, "incrementLike", incrementLike);
   register(app, "decrementLike", decrementLike);
+  register(app, "updateAllCourseMetrics", updateAllCourseMetrics);
 }
 
 function register<T>(app: express.Application, name: string, endpoint: Endpoint<T>) {

--- a/server/endpoints/AdminActions.test.ts
+++ b/server/endpoints/AdminActions.test.ts
@@ -72,7 +72,7 @@ describe('tests', () => {
     await sampleReview.save();
     await newCourse1.save();
     const res = await axios.post(`http://localhost:${testingPort}/v2/makeReviewVisible`, { review: sampleReview, token: "non-empty" });
-    expect(res.data.result).toEqual(1);
+    expect(res.data.result.resCode).toEqual(1);
     const course = await Classes.findOne({ _id: newCourse1._id }).exec();
     expect(course.classDifficulty).toEqual(sampleReview.difficulty);
     expect(course.classWorkload).toEqual(sampleReview.workload);
@@ -83,7 +83,7 @@ describe('tests', () => {
     await reviewToUndoReport.save();
     await newCourse1.save();
     const res = await axios.post(`http://localhost:${testingPort}/v2/undoReportReview`, { review: reviewToUndoReport, token: "non empty" });
-    expect(res.data.result).toEqual(1);
+    expect(res.data.result.resCode).toEqual(1);
     const reviewFromDb = await Reviews.findById(reviewToUndoReport._id).exec();
     expect(reviewFromDb.visible).toEqual(1);
     await reviewToUndoReport.remove();
@@ -93,7 +93,7 @@ describe('tests', () => {
     await sampleReview.save();
     await newCourse1.save();
     const res = await axios.post(`http://localhost:${testingPort}/v2/removeReview`, { review: sampleReview, token: "non-empty" });
-    expect(res.data.result).toEqual(1);
+    expect(res.data.result.resCode).toEqual(1);
     const course = await Classes.findById(newCourse1._id);
     expect(course.classDifficulty).toEqual(null);
     expect(course.classWorkload).toEqual(null);

--- a/server/endpoints/AdminActions.ts
+++ b/server/endpoints/AdminActions.ts
@@ -164,7 +164,7 @@ export const setProfessors: Endpoint<AdminProfessorsRequest> = {
         const semesters = findAllSemesters();
         const val = updateProfessors(semesters);
         if (val) {
-          return { resCode: 1, val: val };
+          return { resCode: 1, value: val };
         }
         return { resCode: 0 };
       }
@@ -192,7 +192,7 @@ export const resetProfessors: Endpoint<AdminProfessorsRequest> = {
         const semesters = findAllSemesters();
         const val = resetProfessorArray(semesters);
         if (val) {
-          return { resCode: 1, val: val };
+          return { resCode: 1, value: val };
         }
         return { resCode: 0 };
       }

--- a/server/server.ts
+++ b/server/server.ts
@@ -7,7 +7,6 @@ import cors from "cors";
 import dotenv from "dotenv";
 import { Meteor } from "./shim";
 import { fetchAddCourses } from "./dbInit";
-import { Classes, Students } from "./dbDefs";
 import { configure } from "./endpoints";
 
 dotenv.config();
@@ -27,6 +26,7 @@ function setup() {
     app.get('*', (_, response) => response.sendFile(path.join(__dirname, '../../client/build/index.html')));
     // eslint-disable-next-line no-console
     configure(app);
+    // eslint-disable-next-line no-console
     app.listen(port, () => console.log(`Listening on port ${port}...`));
   });
 }
@@ -35,6 +35,7 @@ const uri = process.env.MONGODB_URL ? process.env.MONGODB_URL : "this will error
 let localMongoServer;
 
 mongoose.connect(uri, { useNewUrlParser: true, useUnifiedTopology: true }).then(async () => setup()).catch(async (err) => {
+  // eslint-disable-next-line no-console
   console.log("No DB connection defined!");
 
   // If the environment variable is set, create a simple local db to work with
@@ -42,12 +43,14 @@ mongoose.connect(uri, { useNewUrlParser: true, useUnifiedTopology: true }).then(
   // For now, it fetches Fall 2019 classes for you to view
   // This is useful if you need a local db without any hassle, and don't want to risk damage to the staging db
   if (process.env.ALLOW_LOCAL === "1") {
+    // eslint-disable-next-line no-console
     console.log("Falling back to local db!");
     localMongoServer = new MongoMemoryServer();
     const mongoUri = await localMongoServer.getUri();
     await mongoose.connect(mongoUri, { useNewUrlParser: true, useUnifiedTopology: true });
 
-    await fetchAddCourses("https://classes.cornell.edu/api/2.0/", "FA19").catch((err) => console.log(err));
+    // eslint-disable-next-line no-console
+    await fetchAddCourses("https://classes.cornell.edu/api/2.0/", "FA19").catch((e) => console.log(e));
 
     await mongoose.connection.collections.classes.createIndex({ classFull: "text" });
     await mongoose.connection.collections.subjects.createIndex({ subShort: "text" });


### PR DESCRIPTION
### Summary <!-- Required -->

This PR migrates the last bit of backend functionality -- updateAllCourseMetrics, which does exactly what it sounds like.

### Test Plan 

Tested manually. Also added new test cases in `AdminActions.test.ts`

### Notes <!-- Optional -->

It also fixes the odd linter warning in endpoints.ts and a few other places.

### Breaking Changes

Changed some of the return values in AdminActions to the new format they were supposed to be. The endpoints that the frontend used were still the old ones, but we should double check everything works just in case.