### PR TITLE
Fix Admin Login Issue

### DIFF
--- a/client/src/ui/Login.tsx
+++ b/client/src/ui/Login.tsx
@@ -29,7 +29,7 @@ export default class Login extends Component<{}, { message: string; executeLogin
 
   componentWillMount() {
     // The following is used to show admin panel if a user's token is found to be an admin
-    if (Session.get("token") !== "") {
+    if (Session.get("token") && Session.get("token") !== "") {
       axios.post(`/v2/tokenIsAdmin`, { token: Session.get("token") })
         .then((res) => {
           const result = res.data.result;


### PR DESCRIPTION
### Summary <!-- Required -->

When the session token was null/undefined, this was not caught by the if statement that this PR changes, leading to failing backend call with empty data, that was then caught by the express guard, which then led to a HTTP error. This change forces the token to be initialized before the backend call.

### Test Plan <!-- Required -->

Tested locally.
