### PR TITLE
Remove last frontend meteor calls

### DIFF
--- a/client/src/ui/Admin.jsx
+++ b/client/src/ui/Admin.jsx
@@ -95,53 +95,46 @@ export class Admin extends Component {
   // Call when user asks to remove a review. Accesses the Reviews database
   // and deletes the review with this id.
   removeReview(review, isUnapproved) {
-    Meteor.call('removeReview', review, Session.get("token"), (error, result) => {
-      if (!error && result === 1) {
-        console.log("Review removed");
-        if (isUnapproved) {
-          const updatedUnapprovedReviews = this.removeReviewFromList(review, this.state.unapprovedReviews);
-          this.setState({ unapprovedReviews: updatedUnapprovedReviews });
+    axios.post("/v2/removeReview", { review: review, token: Session.get("token") })
+      .then((response) => {
+        const result = response.data.result.resCode;
+        if (result === 1) {
+          console.log("Review removed");
+          if (isUnapproved) {
+            const updatedUnapprovedReviews = this.removeReviewFromList(review, this.state.unapprovedReviews);
+            this.setState({ unapprovedReviews: updatedUnapprovedReviews });
+          } else {
+            console.log(this.state.reportedReviews);
+            const updatedReportedReviews = this.removeReviewFromList(review, this.state.reportedReviews);
+            this.setState({ reportedReviews: updatedReportedReviews });
+          }
         } else {
-          console.log(this.state.reportedReviews);
-          const updatedReportedReviews = this.removeReviewFromList(review, this.state.reportedReviews);
-          this.setState({ reportedReviews: updatedReportedReviews });
+          console.log("Unable to remove review")
         }
-
-      } else {
-        console.log(error)
-      }
-    });
+      });
   }
 
   // Call when user asks to un-report a reported review. Accesses the Reviews database
   // and changes the reported flag for this review to false.
   unReportReview(review) {
-    Meteor.call('undoReportReview', review, Session.get("token"), (error, result) => {
-      if (!error && result === 1) {
-        console.log("Review unreported");
-        const updatedReportedReviews = this.removeReviewFromList(review, this.state.reportedReviews);
-        this.setState({ reportedReviews: updatedReportedReviews });
-      } else {
-        console.log(error)
-      }
-    });
+    axios.post("/v2/undoReportReview", { review: review, token: Session.get("token") })
+      .then((response) => {
+        const result = response.data.result.resCode;
+        if (result === 1) {
+          console.log("Review unreported");
+          const updatedReportedReviews = this.removeReviewFromList(review, this.state.reportedReviews);
+          this.setState({ reportedReviews: updatedReportedReviews });
+        } else {
+          console.log("Unable to undo report review!");
+        }
+      });
   }
 
   // Call when user selects "Add New Semester" button. Runs code to check the
   // course API for new classes and updates classes existing in the database.
   // sShould run once a semester, when new classes are added to the roster.
   addNewSem(initiate) {
-    console.log("updating to new semester");
-    this.setState({ disableNewSem: true, loadingSemester: 1 });
-    Meteor.call('addNewSemester', initiate, Session.get("token"), (error, result) => {
-      if (!error && result === 1) {
-        console.log("Added new semester courses");
-        this.setState({ disableNewSem: false, loadingSemester: 2 });
-      } else {
-        console.log("Error at Meteor Call: addNewSemester");
-        console.log(error);
-      }
-    });
+    console.log("Deprecated functionality");
   }
 
   // Call when user selects "Initialize Database" button. Scrapes the Cornell
@@ -152,45 +145,39 @@ export class Admin extends Component {
   // NOTE: requries an initialize flag to ensure the function is only run on
   // a button click without this, it will run every time this component is created.
   addAllCourses(initiate) {
-    console.log("adding all classes");
-    this.setState({ disableInit: true, loadingInit: 1 });
-    Meteor.call('addAll', initiate, Session.get("token"), (error, result) => {
-      if (!error && result === 1) {
-        console.log("Added new semester courses");
-        this.setState({ disableInit: false, loadingInit: 2 });
-      } else {
-        console.log("Error at Meteor Call :addAll");
-        console.log(error)
-      }
-    });
+    console.log("Deprecated functionality");
   }
 
   updateProfessors(initiate) {
     console.log("Updating professors");
     this.setState({ disableInit: true, loadingProfs: 1 });
-    Meteor.call('setProfessors', initiate, Session.get("token"), (error, result) => {
-      if (!error && result === 1) {
-        console.log("Updated the professors");
-        this.setState({ disableInit: false, loadingProfs: 2 });
-      } else {
-        console.log("Error at Meteor Call :setProfessors");
-        console.log(error)
-      }
-    });
+
+    axios.post("/v2/setProfessors", { token: Session.get("token") })
+      .then((response) => {
+        const result = response.data.result.resCode;
+        if (result === 1) {
+          console.log("Updated the professors");
+          this.setState({ disableInit: false, loadingProfs: 2 });
+        } else {
+          console.log("Error at setProfessors");
+        }
+      });
   }
 
   resetProfessors(initiate) {
     console.log("Setting the professors to an empty array");
     this.setState({ disableInit: true, resettingProfs: 1 });
-    Meteor.call('resetProfessors', initiate, Session.get("token"), (error, result) => {
-      if (!error && result === 1) {
-        console.log("Reset all the professors to empty arrays");
-        this.setState({ disableInit: false, resettingProfs: 2 });
-      } else {
-        console.log("Error at Meteor Call :resetProfessors");
-        console.log(error)
-      }
-    });
+
+    axios.post("/v2/resetProfessors", { token: Session.get("token") })
+      .then((response) => {
+        const result = response.data.result.resCode;
+        if (result === 1) {
+          console.log("Reset all the professors to empty arrays");
+          this.setState({ disableInit: false, resettingProfs: 2 });
+        } else {
+          console.log("Error at resetProfessors");
+        }
+      });
   }
 
   // handle the first click to the "Initialize Database" button. Show an alert

--- a/client/src/ui/CourseReviews.tsx
+++ b/client/src/ui/CourseReviews.tsx
@@ -102,7 +102,7 @@ export class CourseReviews extends Component<Props, State> {
   // Report this review. Find the review in the local database and change
   // its 'reported' flag to true.
   reportReview = (review: ReviewType) => {
-    axios.post("/v2/reportReview", { review: review })
+    axios.post("/v2/reportReview", { id: review._id })
       .then((response) => {
         const result = response.data.result.resCode;
         if (result === 1) {
@@ -113,7 +113,7 @@ export class CourseReviews extends Component<Props, State> {
           this.setState({ reviews: this.state.reviews.slice(0, idx).concat(this.state.reviews.slice(idx + 1)) });
           console.log("Reported review #" + review._id);
         } else {
-          console.log("Error reporting review!")
+          console.log("Error reporting review!");
         }
       });
   };

--- a/client/src/ui/CourseReviews.tsx
+++ b/client/src/ui/CourseReviews.tsx
@@ -102,18 +102,20 @@ export class CourseReviews extends Component<Props, State> {
   // Report this review. Find the review in the local database and change
   // its 'reported' flag to true.
   reportReview = (review: ReviewType) => {
-    Meteor.call('reportReview', review, (error: any, result: 1 | 0) => {
-      if (!error && result === 1) {
-        let idx = 0;
-        while (idx < this.state.reviews.length && this.state.reviews[idx].key !== review._id) {
-          idx++;
+    axios.post("/v2/reportReview", { review: review })
+      .then((response) => {
+        const result = response.data.result.resCode;
+        if (result === 1) {
+          let idx = 0;
+          while (idx < this.state.reviews.length && this.state.reviews[idx].key !== review._id) {
+            idx++;
+          }
+          this.setState({ reviews: this.state.reviews.slice(0, idx).concat(this.state.reviews.slice(idx + 1)) });
+          console.log("Reported review #" + review._id);
+        } else {
+          console.log("Error reporting review!")
         }
-        this.setState({ reviews: this.state.reviews.slice(0, idx).concat(this.state.reviews.slice(idx + 1)) });
-        console.log("reported review #" + review._id);
-      } else {
-        console.log(error)
-      }
-    });
+      });
   };
 
   // Loop through the list of reivews and render them (as a list)

--- a/client/src/ui/Form.jsx
+++ b/client/src/ui/Form.jsx
@@ -208,8 +208,8 @@ export default class Form extends Component {
       : //else
       [] //set to this
     const isCovid = this.state.isCovid;
-    if (text.length > 0
-      && text !== null) {
+
+    if (text.length > 0 && text !== null && this.state.selectedProfessors.length > 0) {
       // create new review object
       const newReview = {
         text: text,
@@ -231,9 +231,11 @@ export default class Form extends Component {
   submitReview() {
     // Call the API insert function
 
-    axios.post("/v2/insertReview", {token: Session.get("token"), 
-    review: Session.get("review") !== "" ? Session.get("review") : this.state.review, 
-    classId: !Session.get("courseId") ? this.props.course._id : Session.get("courseId") }).then(response => {
+    axios.post("/v2/insertReview", {
+      token: Session.get("token"),
+      review: Session.get("review") !== "" ? Session.get("review") : this.state.review,
+      classId: !Session.get("courseId") ? this.props.course._id : Session.get("courseId")
+    }).then(response => {
       const res = response.data.result;
       if (res.error || res.resCode === 1) {
         // Success, so reset form

--- a/client/src/ui/Login.tsx
+++ b/client/src/ui/Login.tsx
@@ -2,7 +2,6 @@ import React, { Component } from 'react';
 import Admin from './Admin.jsx';
 import CUreviewsGoogleLogin from './CUreviewsGoogleLogin';
 import "./css/Login.css";
-import { Meteor } from "../meteor-shim";
 import { Session } from "../meteor-session";
 import axios from 'axios';
 /*

--- a/client/src/ui/Results.jsx
+++ b/client/src/ui/Results.jsx
@@ -1,5 +1,4 @@
 import React, { Component } from 'react';
-import { Meteor } from "../meteor-shim";
 import "./css/Results.css"; // css files
 import Navbar from './Navbar';
 import ResultsDisplay from './ResultsDisplay.jsx';
@@ -28,46 +27,47 @@ export class Results extends Component {
 
   updateResults() {
     if (this.props.match.params.type === "major") {
-      Meteor.call("getCoursesByMajor", this.props.match.params.input.toLowerCase(), (err, courseList) => {
-        if (!err && courseList.length !== 0) {
-          // Save the Class object that matches the request
-          this.setState({
-            courseList: courseList,
-            loading: false
-          });
-        }
-        else {
-          this.setState({
-            courseList: [],
-            loading: false
-          });
-        }
-      });
-    }
-    else if (this.props.match.params.type === "professor") {
-      Meteor.call("getCoursesByProfessor", this.props.match.params.input.split("+").join(" "), (err, courseList) => {
-        if (!err && courseList.length !== 0) {
-          // Save the Class object that matches the request
-          this.setState({
-            courseList: courseList,
-            loading: false
-          });
-        }
-        else {
-          this.setState({
-            courseList: [],
-            loading: false
-          });
-        }
-      });
+      axios.post("/v2/getCoursesByMajor", { query: this.props.match.params.input.toLowerCase() })
+        .then((response) => {
+          const courseList = response.data.result;
+          if (!courseList.error && courseList.length > 0) {
+            // Save the Class object that matches the request
+            this.setState({
+              courseList: courseList,
+              loading: false
+            });
+          } else {
+            this.setState({
+              courseList: [],
+              loading: false
+            });
+          }
+        });
+    } else if (this.props.match.params.type === "professor") {
+      axios.post("/v2/getCoursesByProfessor", { query: this.props.match.params.input.toLowerCase() })
+        .then((response) => {
+          const courseList = response.data.result;
+          if (!courseList.error && courseList.length > 0) {
+            // Save the Class object that matches the request
+            this.setState({
+              courseList: courseList,
+              loading: false
+            });
+          } else {
+            this.setState({
+              courseList: [],
+              loading: false
+            });
+          }
+        });
     }
     else if (this.props.match.params.type === "keyword") {
       let userQuery = this.props.match.params.input.split("+").join(" ");
-      if(userQuery && userQuery.split(" ").length === 1){
+      if (userQuery && userQuery.split(" ").length === 1) {
         userQuery = userQuery.match(/[a-z]+|[^a-z]+/gi).join(" ");
       }
       axios.post(`/v2/getClassesByQuery`, { query: userQuery }).then(response => {
-        const queryCourseList = response.data.result; 
+        const queryCourseList = response.data.result;
         if (queryCourseList.length !== 0) {
           // Save the Class object that matches the request
           this.setState({
@@ -76,14 +76,14 @@ export class Results extends Component {
           });
         }
         else {
-              this.setState({
-                courseList: [],
-                loading: false
-              });
-            }
+          this.setState({
+            courseList: [],
+            loading: false
+          });
         }
+      }
       )
-      .catch(e => console.log("Getting courses failed!"));
+        .catch(e => console.log("Getting courses failed!"));
     }
   }
 
@@ -107,8 +107,8 @@ export class Results extends Component {
       <div className="full-height bg-color">
         <Navbar userInput={userInput} />
         <ResultsDisplay courses={this.state.courseList}
-        userInput={userInput}
-        loading={this.state.loading} type={this.props.match.params.type}/>
+          userInput={userInput}
+          loading={this.state.loading} type={this.props.match.params.type} />
       </div>
     )
   }

--- a/client/src/ui/ResultsDisplay.jsx
+++ b/client/src/ui/ResultsDisplay.jsx
@@ -1,6 +1,5 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-import { Meteor } from '../meteor-shim';
 import "./css/ResultsDisplay.css"; // css files
 import FilteredResult from './FilteredResult.tsx';
 import PreviewCard from './PreviewCard.jsx';
@@ -55,17 +54,17 @@ export default class ResultsDisplay extends Component {
         card_course: this.props.courses[0],
       }, () => this.filterClasses());
     }
-    if(prevProps.userInput !== this.props.userInput){
-      this.setState({filterMap: this.getInitialFilterMap()}, () => this.filterClasses())
+    if (prevProps.userInput !== this.props.userInput) {
+      this.setState({ filterMap: this.getInitialFilterMap() }, () => this.filterClasses())
     }
   }
 
-  getInitialFilterMap(){
+  getInitialFilterMap() {
     return new Map([
-                ["levels", new Map([["1000", true], ["2000", true], ["3000", true], ["4000", true], ["5000+", true]])],
-                ["semesters", new Map([["Fall", true], ["Spring", true]])],
-                ["subjects", []],
-              ]);
+      ["levels", new Map([["1000", true], ["2000", true], ["3000", true], ["4000", true], ["5000+", true]])],
+      ["semesters", new Map([["Fall", true], ["Spring", true]])],
+      ["subjects", []],
+    ]);
   }
 
   // Handles selecting different sort bys
@@ -75,7 +74,7 @@ export default class ResultsDisplay extends Component {
   }
 
   // Helper function to sort()
-  sortBy(courseList, sortByField, fieldDefault, increasing){
+  sortBy(courseList, sortByField, fieldDefault, increasing) {
     courseList = courseList.sort(
       (a, b) => {
         let first = (Number(b[sortByField]) || fieldDefault);
@@ -85,10 +84,10 @@ export default class ResultsDisplay extends Component {
           return (a.classNum - b.classNum);
         }
         else {
-          if(increasing){
+          if (increasing) {
             return (first - second);
           }
-          else{
+          else {
             return (second - first);
           }
 
@@ -104,50 +103,50 @@ export default class ResultsDisplay extends Component {
   // Sorts list of class results by category selected in this.state.selected
   sort() {
     let availableClasses;
-    if (this.state.filteredItems.length === 0){
+    if (this.state.filteredItems.length === 0) {
       availableClasses = this.state.courseList;
     }
-    else{
+    else {
       availableClasses = this.state.filteredItems;
     }
 
-    if (this.state.selected === "relevance"){
+    if (this.state.selected === "relevance") {
       this.sortBy(availableClasses, "score", 0, true);
     }
-    else if (this.state.selected === "rating"){
+    else if (this.state.selected === "rating") {
       this.sortBy(availableClasses, "classRating", 0, true);
     }
-    else if (this.state.selected === "diff"){
+    else if (this.state.selected === "diff") {
       this.sortBy(availableClasses, "classDifficulty", Number.MAX_SAFE_INTEGER, false);
     }
-    else if (this.state.selected === "work"){
+    else if (this.state.selected === "work") {
       this.sortBy(availableClasses, "classWorkload", Number.MAX_SAFE_INTEGER, false);
     }
   }
 
-  filterClasses(){
+  filterClasses() {
 
     let semesters = Array.from(this.state.filterMap.get("semesters").keys()).filter(semester =>
-                                            this.state.filterMap.get("semesters").get(semester))
+      this.state.filterMap.get("semesters").get(semester))
 
     let filteredItems = this.state.courseList.filter(course =>
       semesters.some(semester =>
-        course.classSems.some(element => element.includes(semester.slice(0,2).toUpperCase())))
+        course.classSems.some(element => element.includes(semester.slice(0, 2).toUpperCase())))
     );
 
     let levels = Array.from(this.state.filterMap.get("levels").keys()).filter(level => this.state.filterMap.get("levels").get(level))
     filteredItems = filteredItems.filter(course =>
       levels.some(level =>
-        level === "5000+" ? course.classNum.slice(0,1) >= "5" : course.classNum.slice(0,1) === level.slice(0,1))
+        level === "5000+" ? course.classNum.slice(0, 1) >= "5" : course.classNum.slice(0, 1) === level.slice(0, 1))
     );
 
     let subjects_objects = this.state.filterMap.get("subjects");
-    if(subjects_objects && subjects_objects.length > 0){
+    if (subjects_objects && subjects_objects.length > 0) {
       filteredItems = filteredItems.filter(course =>
         subjects_objects.some(subject_object => course.classSub.toUpperCase() === subject_object.value));
     }
 
-    this.setState({filteredItems: filteredItems}, () => this.sort());
+    this.setState({ filteredItems: filteredItems }, () => this.sort());
 
   }
 
@@ -161,7 +160,7 @@ export default class ResultsDisplay extends Component {
 
     newFilterMap.get(group).set(name, checked);
 
-    this.setState({filterMap: newFilterMap}, () => this.filterClasses());
+    this.setState({ filterMap: newFilterMap }, () => this.filterClasses());
 
   }
 
@@ -206,9 +205,9 @@ export default class ResultsDisplay extends Component {
   }
 
 
-  handleMajorFilterChange(selectedMajors){
+  handleMajorFilterChange(selectedMajors) {
 
-    if(selectedMajors === null){
+    if (selectedMajors === null) {
       selectedMajors = []
     }
 
@@ -216,29 +215,29 @@ export default class ResultsDisplay extends Component {
 
     newFilterMap.set("subjects", selectedMajors)
 
-    this.setState({filterMap: newFilterMap}, () => this.filterClasses());
+    this.setState({ filterMap: newFilterMap }, () => this.filterClasses());
   }
 
-  getSubjectOptions(inputValue, callback){
+  getSubjectOptions(inputValue, callback) {
+    console.log("Deprecated functionality");
+    // Meteor.call("getSubjectsByKeyword", inputValue, (err, subjectList) => {
+    //   if (!err && subjectList && subjectList.length !== 0) {
+    //     // Save the list of Subject objects that matches the request
 
-    Meteor.call("getSubjectsByKeyword", inputValue, (err, subjectList) => {
-      if (!err && subjectList && subjectList.length !== 0) {
-        // Save the list of Subject objects that matches the request
+    //     const subjectOptions = []
+    //     for(const subject in subjectList){
+    //       subjectOptions.push({
+    //         "value" : subjectList[subject].subShort.toUpperCase(),
+    //         "label" : subjectList[subject].subShort.toUpperCase()
+    //       })
+    //     }
 
-        const subjectOptions = []
-        for(const subject in subjectList){
-          subjectOptions.push({
-            "value" : subjectList[subject].subShort.toUpperCase(),
-            "label" : subjectList[subject].subShort.toUpperCase()
-          })
-        }
-
-        callback(subjectOptions)
-      }
-      else {
-        callback([])
-      }
-    });
+    //     callback(subjectOptions)
+    //   }
+    //   else {
+    //     callback([])
+    //   }
+    // });
 
     // callback(this.filterColors(inputValue));
   }
@@ -292,20 +291,20 @@ export default class ResultsDisplay extends Component {
                   onChange={this.handleMajorFilterChange}
                   value={this.state.filterMap.get("subjects")}
                   noOptionsMessage={() => "No Subjects Match"}
-                 />
+                />
               </div>
             </div>
             <div className="col-md-3 col-sm-3 col-xs-3 results">
 
               <div className="row no-left-margin">
                 <div>
-                <p className="results-num-classes-found">We found <strong>{this.state.filteredItems.length === 0 ? this.state.courseList.length : this.state.filteredItems.length}</strong> courses
+                  <p className="results-num-classes-found">We found <strong>{this.state.filteredItems.length === 0 ? this.state.courseList.length : this.state.filteredItems.length}</strong> courses
                   for &quot;{this.props.userInput}&quot;</p></div>
               </div>
               <div className="row no-left-margin">
                 <div className="results-sort-by-container">
                   <p className="results-sort-by-text">
-                  Sort By:
+                    Sort By:
                     </p>
                   <select value={this.state.selected} className="results-sort-by-select" onChange={(e) => this.handleSelect(e)}>
                     <option value="relevance">Relevance</option>

--- a/server/endpoints.ts
+++ b/server/endpoints.ts
@@ -3,8 +3,8 @@ import { validationResult, ValidationChain } from "express-validator";
 import { totalReviews, howManyReviewsEachClass, howManyEachClass, topSubjects, getReviewsOverTimeTop15 } from "./endpoints/AdminChart";
 import { getReviewsByCourseId, getCourseById, insertReview, insertUser, getCourseByInfo, incrementLike, decrementLike } from "./endpoints/Review";
 import { tokenIsAdmin } from "./endpoints/Auth";
-import { getClassesByQuery, getSubjectsByQuery, getProfessorsByQuery } from "./endpoints/Search";
-import { makeReviewVisible, undoReportReview, removeReview } from "./endpoints/AdminActions";
+import { getCoursesByProfessor, getCoursesByMajor, getClassesByQuery, getSubjectsByQuery, getProfessorsByQuery } from "./endpoints/Search";
+import { reportReview, makeReviewVisible, undoReportReview, removeReview } from "./endpoints/AdminActions";
 
 export interface Context {
   ip: string;
@@ -32,11 +32,14 @@ export function configure(app: express.Application) {
   register(app, "getCourseById", getCourseById);
   register(app, "tokenIsAdmin", tokenIsAdmin);
   register(app, "getSubjectsByQuery", getSubjectsByQuery);
+  register(app, "getCoursesByMajor", getCoursesByMajor);
   register(app, "getProfessorsByQuery", getProfessorsByQuery);
+  register(app, "getCoursesByProfessor", getCoursesByProfessor);
   register(app, "insertReview", insertReview);
   register(app, "insertUser", insertUser);
   register(app, "makeReviewVisible", makeReviewVisible);
   register(app, "undoReportReview", undoReportReview);
+  register(app, "reportReview", reportReview);
   register(app, "removeReview", removeReview);
   register(app, "getCourseByInfo", getCourseByInfo);
   register(app, "totalReviews", totalReviews);

--- a/server/endpoints/AdminActions.test.ts
+++ b/server/endpoints/AdminActions.test.ts
@@ -83,7 +83,7 @@ describe('tests', () => {
     await reviewToUndoReport.save();
     await newCourse1.save();
     const res = await axios.post(`http://localhost:${testingPort}/v2/undoReportReview`, { review: reviewToUndoReport, token: "non empty" });
-    expect(res.data.result).toEqual(1);
+    expect(res.data.result.resCode).toEqual(1);
     const reviewFromDb = await Reviews.findById(reviewToUndoReport._id).exec();
     expect(reviewFromDb.visible).toEqual(1);
     await reviewToUndoReport.remove();
@@ -93,7 +93,7 @@ describe('tests', () => {
     await sampleReview.save();
     await newCourse1.save();
     const res = await axios.post(`http://localhost:${testingPort}/v2/removeReview`, { review: sampleReview, token: "non-empty" });
-    expect(res.data.result).toEqual(1);
+    expect(res.data.result.resCode).toEqual(1);
     const course = await Classes.findById(newCourse1._id);
     expect(course.classDifficulty).toEqual(null);
     expect(course.classWorkload).toEqual(null);

--- a/server/endpoints/AdminActions.ts
+++ b/server/endpoints/AdminActions.ts
@@ -186,7 +186,7 @@ export const reportReview: Endpoint<ReviewRequest> = {
   callback: async (ctx: Context, request: ReviewRequest) => {
     try {
       await Reviews.updateOne({ _id: request.id }, { $set: { visible: 0, reported: 1 } });
-      let course = (await Reviews.findOne({ _id: request.id })).class;
+      const course = (await Reviews.findOne({ _id: request.id })).class;
       const res = await updateCourseMetrics(course);
       return { resCode: res.resCode };
     } catch (error) {

--- a/server/endpoints/AdminActions.ts
+++ b/server/endpoints/AdminActions.ts
@@ -5,6 +5,8 @@ import { Context, Endpoint } from "../endpoints";
 import { Reviews, ReviewDocument, Classes } from "../dbDefs";
 import { updateProfessors, findAllSemesters, resetProfessorArray } from "../dbInit";
 import { getCourseById, verifyToken } from "./utils";
+import { ReviewRequest } from "./Review";
+
 
 // The type for a request with an admin action for a review
 interface AdminReviewRequest {
@@ -19,35 +21,31 @@ interface AdminProfessorsRequest {
 
 // This updates the metrics for an individual class given its Mongo-generated id.
 // Returns 1 if successful, 0 otherwise.
-export const updateCourseMetrics = async (courseId, token) => {
+export const updateCourseMetrics = async (courseId) => {
   try {
-    const userIsAdmin = await verifyToken(token);
-    if (userIsAdmin) {
-      const course = await getCourseById({ courseId });
-      if (course) {
-        const crossListOR = getCrossListOR(course);
-        const reviews = await Reviews.find({ visible: 1, reported: 0, $or: crossListOR }, {}, { sort: { date: -1 }, limit: 700 }).exec();
-        const state = getMetricValues(reviews);
-        await Classes.updateOne({ _id: courseId },
-          {
-            $set: {
-              // If no data is available, getMetricValues returns "-" for metric
-              classDifficulty: (state.diff !== "-" && !isNaN(Number(state.diff)) ? Number(state.diff) : null),
-              classRating: (state.rating !== "-" && !isNaN(Number(state.rating)) ? Number(state.rating) : null),
-              classWorkload: (state.workload !== "-" && !isNaN(Number(state.workload)) ? Number(state.workload) : null),
-            },
-          });
-        return 1;
-      }
-      return 0;
+    const course = await getCourseById({ courseId });
+    if (course) {
+      const crossListOR = getCrossListOR(course);
+      const reviews = await Reviews.find({ visible: 1, reported: 0, $or: crossListOR }, {}, { sort: { date: -1 }, limit: 700 }).exec();
+      const state = getMetricValues(reviews);
+      await Classes.updateOne({ _id: courseId },
+        {
+          $set: {
+            // If no data is available, getMetricValues returns "-" for metric
+            classDifficulty: (state.diff !== "-" && !isNaN(Number(state.diff)) ? Number(state.diff) : null),
+            classRating: (state.rating !== "-" && !isNaN(Number(state.rating)) ? Number(state.rating) : null),
+            classWorkload: (state.workload !== "-" && !isNaN(Number(state.workload)) ? Number(state.workload) : null),
+          },
+        });
+      return { resCode: 1 };
     }
-    return 0;
+    return { resCode: 0 };
   } catch (error) {
     // eslint-disable-next-line no-console
     console.log("Error: at 'updateCourseMetrics' method");
     // eslint-disable-next-line no-console
     console.log(error);
-    return 0;
+    return { resCode: 0 };
   }
 };
 
@@ -63,7 +61,8 @@ export const makeReviewVisible: Endpoint<AdminReviewRequest> = {
       const regex = new RegExp(/^(?=.*[A-Z0-9])/i);
       if (regex.test(adminReviewRequest.review._id) && userIsAdmin) {
         await Reviews.updateOne({ _id: adminReviewRequest.review._id }, { $set: { visible: 1 } });
-        await updateCourseMetrics(adminReviewRequest.review.class, adminReviewRequest.token);
+        await updateCourseMetrics(adminReviewRequest.review.class);
+
         return { resCode: 1 };
       }
     } catch (error) {
@@ -86,15 +85,16 @@ export const undoReportReview: Endpoint<AdminReviewRequest> = {
       const userIsAdmin = await verifyToken(adminReviewRequest.token);
       if (userIsAdmin) {
         await Reviews.updateOne({ _id: adminReviewRequest.review._id }, { $set: { visible: 1, reported: 0 } });
-        return 1;
+        await updateCourseMetrics(adminReviewRequest.review.class);
+        return { resCode: 1 };
       }
-      return 0;
+      return { resCode: 0 };
     } catch (error) {
       // eslint-disable-next-line no-console
       console.log("Error: at 'undoReportReview' method");
       // eslint-disable-next-line no-console
       console.log(error);
-      return 0;
+      return { resCode: 0 };
     }
   },
 };
@@ -109,16 +109,16 @@ export const removeReview: Endpoint<AdminReviewRequest> = {
       const userIsAdmin = await verifyToken(adminReviewRequest.token);
       if (userIsAdmin) {
         await Reviews.remove({ _id: adminReviewRequest.review._id });
-        await updateCourseMetrics(adminReviewRequest.review.class, adminReviewRequest.token);
-        return 1;
+        let res = await updateCourseMetrics(adminReviewRequest.review.class);
+        return { resCode: res.resCode };
       }
-      return 0;
+      return { resCode: 0 };
     } catch (error) {
       // eslint-disable-next-line no-console
       console.log("Error: at 'removeReview' method");
       // eslint-disable-next-line no-console
       console.log(error);
-      return 0;
+      return { resCode: 0 };
     }
   },
 };
@@ -135,17 +135,17 @@ export const setProfessors: Endpoint<AdminProfessorsRequest> = {
         const semesters = findAllSemesters();
         const val = updateProfessors(semesters);
         if (val) {
-          return val;
+          return { resCode: val };
         }
-        return 0;
+        return { resCode: 0 };
       }
-      return 0;
+      return { resCode: 0 };
     } catch (error) {
       // eslint-disable-next-line no-console
       console.log("Error: at 'setProfessors' ");
       // eslint-disable-next-line no-console
       console.log(error);
-      return 0;
+      return { resCode: 0 };
     }
   },
 };
@@ -163,17 +163,34 @@ export const resetProfessors: Endpoint<AdminProfessorsRequest> = {
         const semesters = findAllSemesters();
         const val = resetProfessorArray(semesters);
         if (val) {
-          return val;
+          return { resCode: val };
         }
-        return 0;
+        return { resCode: 0 };
       }
-      return 0;
+      return { resCode: 0 };
     } catch (error) {
       // eslint-disable-next-line no-console
       console.log("Error: at 'resetProfessors' method");
       // eslint-disable-next-line no-console
       console.log(error);
-      return 0;
+      return { resCode: 0 };
+    }
+  },
+};
+
+export const reportReview: Endpoint<ReviewRequest> = {
+  guard: [body("id").notEmpty().isAscii()],
+  callback: async (ctx: Context, request: ReviewRequest) => {
+    try {
+      await Reviews.updateOne({ _id: request.id }, { $set: { visible: 0, reported: 1 } });
+      const res = await updateCourseMetrics(request.id);
+      return { resCode: res.resCode };
+    } catch (error) {
+      // eslint-disable-next-line no-console
+      console.log("Error: at 'reportReview' method");
+      // eslint-disable-next-line no-console
+      console.log(error);
+      return { resCode: 0 };
     }
   },
 };

--- a/server/endpoints/AdminActions.ts
+++ b/server/endpoints/AdminActions.ts
@@ -39,6 +39,9 @@ export const updateCourseMetrics = async (courseId) => {
         });
       return { resCode: 1 };
     }
+
+    // eslint-disable-next-line no-console
+    console.log(`updateCourseMetrics unable to find id ${courseId}`);
     return { resCode: 0 };
   } catch (error) {
     // eslint-disable-next-line no-console
@@ -79,7 +82,7 @@ export const makeReviewVisible: Endpoint<AdminReviewRequest> = {
  * "Undo" the reporting of a flagged review and make it visible again
  */
 export const undoReportReview: Endpoint<AdminReviewRequest> = {
-  guard: [body("review").notEmpty(), body("token").notEmpty().isAscii(), body("review._id").isAlphanumeric()],
+  guard: [body("review").notEmpty(), body("token").notEmpty().isAscii(), body("review._id").isAscii()],
   callback: async (ctx: Context, adminReviewRequest: AdminReviewRequest) => {
     try {
       const userIsAdmin = await verifyToken(adminReviewRequest.token);
@@ -103,7 +106,7 @@ export const undoReportReview: Endpoint<AdminReviewRequest> = {
  * Remove a review, used for both submitted and flagged reviews
  */
 export const removeReview: Endpoint<AdminReviewRequest> = {
-  guard: [body("review").notEmpty(), body("token").notEmpty().isAscii(), body("review._id").isAlphanumeric()],
+  guard: [body("review").notEmpty(), body("token").notEmpty().isAscii(), body("review._id").isAscii()],
   callback: async (ctx: Context, adminReviewRequest: AdminReviewRequest) => {
     try {
       const userIsAdmin = await verifyToken(adminReviewRequest.token);
@@ -183,7 +186,8 @@ export const reportReview: Endpoint<ReviewRequest> = {
   callback: async (ctx: Context, request: ReviewRequest) => {
     try {
       await Reviews.updateOne({ _id: request.id }, { $set: { visible: 0, reported: 1 } });
-      const res = await updateCourseMetrics(request.id);
+      let course = (await Reviews.findOne({ _id: request.id })).class;
+      const res = await updateCourseMetrics(course);
       return { resCode: res.resCode };
     } catch (error) {
       // eslint-disable-next-line no-console

--- a/server/endpoints/AdminActions.ts
+++ b/server/endpoints/AdminActions.ts
@@ -109,7 +109,7 @@ export const removeReview: Endpoint<AdminReviewRequest> = {
       const userIsAdmin = await verifyToken(adminReviewRequest.token);
       if (userIsAdmin) {
         await Reviews.remove({ _id: adminReviewRequest.review._id });
-        let res = await updateCourseMetrics(adminReviewRequest.review.class);
+        const res = await updateCourseMetrics(adminReviewRequest.review.class);
         return { resCode: res.resCode };
       }
       return { resCode: 0 };

--- a/server/endpoints/Review.ts
+++ b/server/endpoints/Review.ts
@@ -30,7 +30,7 @@ interface ClassByInfoQuery {
   number: string;
 }
 
-export interface LikeRequest {
+export interface ReviewRequest {
   id: string;
 }
 
@@ -175,9 +175,9 @@ export const insertReview: Endpoint<InsertReviewRequest> = {
  *
  * TODO: migrate to a proper account-based solution
  */
-export const incrementLike: Endpoint<LikeRequest> = {
+export const incrementLike: Endpoint<ReviewRequest> = {
   guard: [body("id").notEmpty().isAscii()],
-  callback: async (ctx: Context, request: LikeRequest) => {
+  callback: async (ctx: Context, request: ReviewRequest) => {
     try {
       const review = await Reviews.findOne({ _id: request.id }).exec();
 
@@ -209,9 +209,9 @@ export const incrementLike: Endpoint<LikeRequest> = {
  * Returns resCole 0 on error
  */
 
-export const decrementLike: Endpoint<LikeRequest> = {
+export const decrementLike: Endpoint<ReviewRequest> = {
   guard: [body("id").notEmpty().isAscii()],
-  callback: async (ctx: Context, request: LikeRequest) => {
+  callback: async (ctx: Context, request: ReviewRequest) => {
     try {
       const review = await Reviews.findOne({ _id: request.id }).exec();
 

--- a/server/endpoints/Search.ts
+++ b/server/endpoints/Search.ts
@@ -5,7 +5,7 @@ import { Classes, Subjects, Professors } from "../dbDefs";
 
 // The type for a search query
 interface Search {
-    query: string;
+  query: string;
 }
 
 /*
@@ -54,7 +54,7 @@ const courseSort = (query) => (a, b) => {
   const bCourseStr = `${b.classSub} ${b.classNum}`;
   const queryLen = query.length;
   return editDistance(query.toLowerCase(), aCourseStr.slice(0, queryLen))
-      - editDistance(query.toLowerCase(), bCourseStr.slice(0, queryLen));
+    - editDistance(query.toLowerCase(), bCourseStr.slice(0, queryLen));
 };
 
 // Helper to check if a string is a subject code
@@ -183,6 +183,46 @@ export const getProfessorsByQuery: Endpoint<Search> = {
     } catch (error) {
       // eslint-disable-next-line no-console
       console.log("Error: at 'getProfessorsByQuery' endpoint");
+      // eslint-disable-next-line no-console
+      console.log(error);
+      return { error: "Internal Server Error" };
+    }
+  },
+};
+
+export const getCoursesByMajor: Endpoint<Search> = {
+  guard: [body("query").notEmpty().isAscii()],
+  callback: async (ctx: Context, search: Search) => {
+    try {
+      let courses = [];
+      const regex = new RegExp(/^(?=.*[A-Z0-9])/i);
+      if (regex.test(search.query)) {
+        courses = await Classes.find({ classSub: search.query }).exec();
+      }
+      return courses;
+    } catch (error) {
+      // eslint-disable-next-line no-console
+      console.log("Error: at 'getCoursesByMajor' method");
+      // eslint-disable-next-line no-console
+      console.log(error);
+      return { error: "Internal Server Error" };
+    }
+  },
+};
+
+export const getCoursesByProfessor: Endpoint<Search> = {
+  guard: [body("query").notEmpty().isAscii()],
+  callback: async (ctx: Context, search: Search) => {
+    try {
+      let courses = [];
+      const regex = new RegExp(/^(?=.*[A-Z0-9])/i);
+      if (regex.test(search.query)) {
+        courses = await Classes.find({ classProfessors: search.query }).exec();
+      }
+      return courses;
+    } catch (error) {
+      // eslint-disable-next-line no-console
+      console.log("Error: at 'getCoursesByProfessor' method");
       // eslint-disable-next-line no-console
       console.log(error);
       return { error: "Internal Server Error" };


### PR DESCRIPTION
### Summary <!-- Required -->

This PR migrates the last bit of Meteor call functionality. In particular, these are some admin actions, some search related functionality, and the reporting functionality. There are all very similar.

It also adds some express endpoints for functions which seem to never have been called. We should look into whether or not we can ditch them.

### Test Plan

Tested locally. Also adjusted backend tests where relevant.

### Notes <!-- Optional -->

There will need to be another PR to deprecate Meteor subscriptions. There will need to be then the final PR to disable meteor.

There were some Meteor calls to non-existent Meteor methods. These calls have been removed.