### PR TITLE
Fix relevance of search bar suggestions

### DIFF
--- a/client/src/ui/Course.tsx
+++ b/client/src/ui/Course.tsx
@@ -37,9 +37,13 @@ export default class Course extends Component<Props> {
       }
     // check if a query was provided, if so underline parts of the class name
     if (this.props.query) {
-      if (text.toLowerCase().indexOf(this.props.query) !== -1) {
-        const startIndex = text.toLowerCase().indexOf(this.props.query);
-        const endIndex = startIndex + this.props.query.length;
+      const textLowerCase = text.toLowerCase();
+      const queryLowerCase = this.props.query.toLowerCase();
+      const queryIndex = textLowerCase.indexOf(queryLowerCase)
+
+      if (queryIndex !== -1) {
+        const startIndex = queryIndex;
+        const endIndex = startIndex + queryLowerCase.length;
         text = <span className="ellipsis">{text.substring(0,startIndex)}<span className='matching-text'>{text.substring(startIndex,endIndex)}</span>{text.substring(endIndex)}</span>
       } else {
         // based on search technique in server/publications, results without a contains match
@@ -47,7 +51,7 @@ export default class Course extends Component<Props> {
         // text in the substring of query after the subject.
 
         // substring of query after the subject, without trailing spaces
-        const queryWithoutSubject = this.props.query.substring(classInfo.classSub.length).trim();
+        const queryWithoutSubject = queryLowerCase.substring(classInfo.classSub.length).trim();
         // search substring of text after subject for substring of query.
         const textWithoutSubject = classInfo.classNum + ": " + classInfo.classTitle;
         const startIndex = textWithoutSubject.toLowerCase().indexOf(queryWithoutSubject);

--- a/client/src/ui/SearchBar.jsx
+++ b/client/src/ui/SearchBar.jsx
@@ -39,6 +39,10 @@ const initState = {
 
 export default class SearchBar extends Component {
 
+  static DEBOUNCE_TIME = 200;
+  controller;
+  searchTimeout;
+
   constructor(props) {
     super(props);
 
@@ -71,57 +75,102 @@ export default class SearchBar extends Component {
     Session.setPersistent({"last-search": query});
   }
 
-  componentDidUpdate(prevProps, prevState) {
-    if (this.state.query.toLowerCase() !== "" && (this.state.query.toLowerCase() !== prevState.query.toLowerCase() || this.props !== prevProps)) {
-      axios.post(`/v2/getClassesByQuery`, { query: this.state.query }).then(response => {
-        const queryCourseList = response.data.result;
-        if (queryCourseList.length !== 0) {
-          // Save the Class object that matches the request
-          this.setState({
-            allCourses: queryCourseList.sort(
-              (a, b) => b.score - a.score || a.classNum - b.classNum
-            ),
-          });
-        }
-        else {
-          this.setState({
-            allCourses: []
-          });
-        }
+  /**
+   * Compares classes based on score, then class number, then alphabetically by
+   * subject.
+   * @param {Class} a 
+   * @param {Class} b 
+   * @returns -1, 0, or 1
+   */
+  sortCourses(a, b) {
+    const sortByAlphabet = (a, b) => {
+      const aSub = a.classSub.toLowerCase();
+      const bSub = b.classSub.toLowerCase();
+      if (aSub < bSub) {
+        return -1;
+      } else if (aSub > bSub) {
+        return 1;
+      } else {
+        return 0;
       }
-      )
-        .catch(e => console.log("Getting courses failed!"));
+    };
 
-      axios.post(`/v2/getSubjectsByQuery`, { query: this.state.query }).then(response => {
-        const subjectList = response.data.result;
-        if (subjectList && subjectList.length !== 0) {
-          // Save the list of Subject objects that matches the request
-          this.setState({
-            allSubjects: subjectList
-          });
-        }
-        else {
-          this.setState({
-            allSubjects: []
-          });
-        }
-      }).catch(e => console.log("Getting subjects failed!"));
+    return b.score - a.score || a.classNum - b.classNum || sortByAlphabet(a, b);
+  }
 
-      axios.post(`/v2/getProfessorsByQuery`, { query: this.state.query }).then(response => {
-        const professorList = response.data.result;
-        if (professorList && professorList.length !== 0) {
-          // Save the list of Subject objects that matches the request
-          this.setState({
-            allProfessors: professorList
-          });
-        }
-        else {
-          this.setState({
-            allProfessors: []
-          });
-        }
-      }).catch(e => console.log("Getting professors failed!"));
+  componentDidUpdate(prevProps, prevState) {
+    if (
+      this.state.query.toLowerCase() !== "" &&
+      (this.state.query.toLowerCase() !== prevState.query.toLowerCase() ||
+        this.props !== prevProps)
+    ) {
+      if (this.controller) this.controller.abort();
+      this.controller = new AbortController();
+      clearTimeout(this.searchTimeout);
 
+      this.searchTimeout = setTimeout(() => {
+        axios
+          .post(
+            `/v2/getClassesByQuery`,
+            { query: this.state.query },
+            { signal: this.controller.signal }
+          )
+          .then((response) => {
+            const queryCourseList = response.data.result;
+            if (queryCourseList.length !== 0) {
+              this.setState({
+                allCourses: queryCourseList.sort(this.sortCourses),
+              });
+            } else {
+              this.setState({
+                allCourses: [],
+              });
+            }
+          })
+          .catch((e) => console.log("Getting courses failed!"));
+
+      axios
+        .post(
+          `/v2/getSubjectsByQuery`,
+          { query: this.state.query },
+          { signal: this.controller.signal }
+        )
+        .then((response) => {
+          const subjectList = response.data.result;
+          if (subjectList && subjectList.length !== 0) {
+            // Save the list of Subject objects that matches the request
+            this.setState({
+              allSubjects: subjectList,
+            });
+          } else {
+            this.setState({
+              allSubjects: [],
+            });
+          }
+        })
+        .catch((e) => console.log("Getting subjects failed!"));
+
+      axios
+        .post(
+          `/v2/getProfessorsByQuery`,
+          { query: this.state.query },
+          { signal: this.controller.signal }
+        )
+        .then((response) => {
+          const professorList = response.data.result;
+          if (professorList && professorList.length !== 0) {
+            // Save the list of Subject objects that matches the request
+            this.setState({
+              allProfessors: professorList,
+            });
+          } else {
+            this.setState({
+              allProfessors: [],
+            });
+          }
+        })
+        .catch((e) => console.log("Getting professors failed!"));
+      }, this.DEBOUNCE_TIME)
     }
   }
 

--- a/client/src/ui/SearchBar.jsx
+++ b/client/src/ui/SearchBar.jsx
@@ -78,7 +78,9 @@ export default class SearchBar extends Component {
         if (queryCourseList.length !== 0) {
           // Save the Class object that matches the request
           this.setState({
-            allCourses: queryCourseList
+            allCourses: queryCourseList.sort(
+              (a, b) => b.score - a.score || a.classNum - b.classNum
+            ),
           });
         }
         else {


### PR DESCRIPTION
### Summary <!-- Required -->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Itemize bug fixes, new features, and other changes -->
<!-- Feel free to break this into sub-sections, i.e. features, fixes, etc. -->
<!-- Some examples are shown below. -->

The search bar shows somewhat irrelevant search suggestions. For example, searching in our current production website exhibits two main issues:

1. the suggestions aren't sorted correctly and don't match with the search results on the `/results` page
2. searching the same term can lead to different suggestions depending on typing and network speed

Example of issue 1: Searching "operating systems" shows pretty irrelevant suggestions in the search bar, but the actual results returned in the `/results` page are much more relevant.
![image](https://user-images.githubusercontent.com/11168401/158096538-041b4dd1-72b4-4c67-875d-af045d2ee10e.png)

Example of issue 2: Typing in "2110" multiple times into the search bar leads to different suggestions each time.
| 1 | 2 | 3 |
| --- | --- | --- |
| ![image](https://user-images.githubusercontent.com/11168401/158096950-13c2baf1-0837-41dd-9435-7fd7f8c99ae8.png) | ![image](https://user-images.githubusercontent.com/11168401/158096974-a09fc2f6-d91e-4a25-af94-c8593889b624.png) | ![image](https://user-images.githubusercontent.com/11168401/158097002-03102a06-6c87-4d17-9f6f-bfeda8d1f022.png) |

This PR fixes both these issues by:

1. sorting suggestions based on their relevance score and then by course number (this is what the `/results` page components do)
2. debouncing search input and cancelling network requests when user inputs a new search string

### Test Plan <!-- Required -->

<!-- Provide screenshots or point out the additional unit tests -->

Here are some sample searches before and after the changes.
| before | after |
| --- | --- |
| ![image](https://user-images.githubusercontent.com/11168401/159173348-5d9530d8-92bc-4b03-b87e-f02c8ee98d26.png) | ![image](https://user-images.githubusercontent.com/11168401/159173417-2bea21fb-6e34-494c-bf1a-f1155bfe392b.png) |
| ![image](https://user-images.githubusercontent.com/11168401/159173471-e94304f4-0df2-447a-ab05-9c1811786db4.png) | ![image](https://user-images.githubusercontent.com/11168401/159173477-4f8af913-dba6-4f8e-8b82-6aff9e437b52.png) |

### Linter Warnings <!-- Required -->

<!-- Please make sure that you are not adding linter warnings. Similarly, make sure that `yarn workspace client run` yields no warnings. -->

None.

### Notes <!-- Optional -->

<!--- List any important or subtle points, future considerations, or other items of note. -->
I have set debounce time to `200ms` because this seems to be a good balance between not updating suggestions and minimizing async issues. See some references here:

- https://ux.stackexchange.com/questions/95336/how-long-should-the-debounce-timeout-be
- https://blog.logrocket.com/how-and-when-to-debounce-or-throttle-in-react/

Right now, we render majors and professors above classes regardless of their similarity scores. Should we consider reordering these according to their similarity score?
![image](https://user-images.githubusercontent.com/11168401/159140495-0f7406cc-f00e-45ac-be0d-8bab4b57886a.png)

Additionally, should we consider sorting on server?

Read more notes on the Notion doc here: https://www.notion.so/cornelldti/Fix-search-features-f9a29d71c9dc436baf78a2fbbf226f26