### PR TITLE
Enable user to add unlisted professors

### DIFF
--- a/client/src/ui/ReviewForm.tsx
+++ b/client/src/ui/ReviewForm.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from "react";
-import Select from "react-select";
+import CreatableSelect from "react-select/creatable";
 import RatingInput from "./RatingInput";
 import styles from "./css/ReviewForm.module.css";
 
@@ -72,7 +72,7 @@ export default function ReviewForm({
         >
           Professor
         </label>
-        <Select
+        <CreatableSelect
           value={toSelectOptions(selectedProfessors)}
           onChange={(professors: any) => {
             setIsSelectedProfessorsInvalid(false);


### PR DESCRIPTION
### Summary <!-- Required -->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Itemize bug fixes, new features, and other changes -->
<!-- Feel free to break this into sub-sections, i.e. features, fixes, etc. -->
<!-- Some examples are shown below. -->

This pull request adds the ability for users to add unlisted professors. This is a fail-safe for when we don't have an up-to-date list of professors for each class. 

This uses [`CreatableSelect` from `react-select`](https://react-select.com/home#creatable) to allow user input in the select dropdown for professors.

### Test Plan <!-- Required -->

<!-- Provide screenshots or point out the additional unit tests -->
Tested adding custom professors and verifying that these reviews show up in the `/admin` panel.

| review | admin |
| --- | --- |
| ![image](https://user-images.githubusercontent.com/11168401/163743618-e8caf349-d04b-4866-ad21-dd071c06e726.png) | ![image](https://user-images.githubusercontent.com/11168401/163743663-2afa904e-d5ba-4b44-828d-c3113f2243e8.png) |

### Linter Warnings <!-- Required -->

<!-- Please make sure that you are not adding linter warnings. Similarly, make sure that `yarn workspace client run` yields no warnings. -->

none

### Notes <!-- Optional -->

<!--- List any important or subtle points, future considerations, or other items of note. -->
For the future, we should just make sure we update the professor lists. Otherwise, we might have some inconsistencies with professor names (e.g., someone might type "Gries" or "Prof Gries" or "David Gries").