### PR TITLE
Fix CI tests using jest-circus test runner

### DIFF
--- a/server/dbInit.test.ts
+++ b/server/dbInit.test.ts
@@ -6,10 +6,6 @@ import mongoose from "mongoose";
 import { Subjects, Classes, Professors } from "./dbDefs";
 import { fetchSubjects, fetchClassesForSubject, fetchAddCourses } from "./dbInit";
 
-// May require additional time for downloading 100 mb (!) worth of MongoDB binaries
-// **We might not want to run this with CI**
-jasmine.DEFAULT_TIMEOUT_INTERVAL = 600000;
-
 let testServer: MongoMemoryServer;
 let serverCloseHandle;
 

--- a/server/package.json
+++ b/server/package.json
@@ -14,6 +14,8 @@
   },
   "jest": {
     "testEnvironment": "node",
+    "testRunner": "jest-circus/runner",
+    "testTimeout": 20000,
     "moduleFileExtensions": [
       "js",
       "ts"
@@ -43,6 +45,7 @@
     "@types/jest": "^25.2.1",
     "@types/mongodb": "^3.5.4",
     "@types/mongoose": "^5.7.7",
+    "jest-circus": "24",
     "ts-jest": "24"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -6375,6 +6375,28 @@ jest-changed-files@^24.9.0:
     execa "^1.0.0"
     throat "^4.0.0"
 
+jest-circus@24:
+  version "24.9.0"
+  resolved "https://registry.yarnpkg.com/jest-circus/-/jest-circus-24.9.0.tgz#8a557683636807d537507eac02ba64c95b686485"
+  integrity sha512-dwkvwFtRc9Anmk1XTc+bonVL8rVMZ3CeGMoFWmv1oaQThdAgvfI9bwaFlZp+gLVphNVz6ZLfCWo3ERhS5CeVvA==
+  dependencies:
+    "@babel/traverse" "^7.1.0"
+    "@jest/environment" "^24.9.0"
+    "@jest/test-result" "^24.9.0"
+    "@jest/types" "^24.9.0"
+    chalk "^2.0.1"
+    co "^4.6.0"
+    expect "^24.9.0"
+    is-generator-fn "^2.0.0"
+    jest-each "^24.9.0"
+    jest-matcher-utils "^24.9.0"
+    jest-message-util "^24.9.0"
+    jest-snapshot "^24.9.0"
+    jest-util "^24.9.0"
+    pretty-format "^24.9.0"
+    stack-utils "^1.0.1"
+    throat "^4.0.0"
+
 jest-cli@^24.9.0:
   version "24.9.0"
   resolved "https://registry.yarnpkg.com/jest-cli/-/jest-cli-24.9.0.tgz#ad2de62d07472d419c6abc301fc432b98b10d2af"


### PR DESCRIPTION
### Summary <!-- Required -->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Itemize bug fixes, new features, and other changes -->
<!-- Feel free to break this into sub-sections, i.e. features, fixes, etc. -->
<!-- Some examples are shown below. -->

This pull request fixes the CI build issues related to uninitialized indexes on the testing instance of our database. Looking at the commit history on `master`, you can see that some commits fail to build due to this issue (see notes for part of the error output).

This changes the test runner for our Jest setup from `jasmine2` to `jest-circus`. This is the newer test runner for Jest (default since Jest 27), which we have to manually enable for our older version of Jest (Jest 24).

For more context on the process of fixing this issue, see [this Notion document](https://www.notion.so/cornelldti/Fix-deployments-and-testing-1476b3f259e049728d79e834ecb5c4de).

### Test Plan <!-- Required -->

<!-- Provide screenshots or point out the additional unit tests -->

Tested using [`act`](https://github.com/nektos/act), which allows us to run GitHub Actions locally. 

Before the fixes, the CI actions failed. After the fixes, the CI actions passed.

### Linter Warnings <!-- Required -->

<!-- Please make sure that you are not adding linter warnings. Similarly, make sure that `yarn workspace client run` yields no warnings. -->

n/a

### Breaking Changes  <!-- Optional -->

- removes references to previous Jasmine runner

### Notes <!-- Optional -->

Example of failed build output. See [this CI run for full output](https://github.com/cornell-dti/course-reviews-react-2.0/runs/6149944549).
```
Downloading MongoDB 4.0.14: 0 % (0mb / 99.4mb)
FAIL endpoints/Search.test.ts (11.113s)
  ● Console

    console.log endpoints/Search.ts:155
      Error: at 'getClassesByQuery' endpoint
    console.log endpoints/Search.ts:157
      { MongoError: text index required for $text query (no such collection '55cdefc1-7733-4ae2-aac9-9ba74a26234d.classes')
          at MessageStream.messageHandler (/home/runner/work/course-reviews-react-2.0/course-reviews-react-2.0/node_modules/mongodb/lib/cmap/connection.js:261:20)
          at MessageStream.emit (events.js:198:13)
          at processIncomingData (/home/runner/work/course-reviews-react-2.0/course-reviews-react-2.0/node_modules/mongodb/lib/cmap/message_stream.js:144:12)
          at MessageStream._write (/home/runner/work/course-reviews-react-2.0/course-reviews-react-2.0/node_modules/mongodb/lib/cmap/message_stream.js:42:5)
          at doWrite (_stream_writable.js:415:12)
          at writeOrBuffer (_stream_writable.js:399:5)
          at MessageStream.Writable.write (_stream_writable.js:299:11)
          at Socket.ondata (_stream_readable.js:710:20)
          at Socket.emit (events.js:198:13)
          at addChunk (_stream_readable.js:288:12)
          at readableAddChunk (_stream_readable.js:269:11)
          at Socket.Readable.push (_stream_readable.js:224:10)
          at TCP.onStreamRead [as onread] (internal/stream_base_commons.js:94:17)
        ok: 0,
        errmsg:
         'text index required for $text query (no such collection \'55cdefc1-7733-4ae2-aac9-9ba74a26234d.classes\')',
        code: 27,
        codeName: 'IndexNotFound',
        name: 'MongoError',
        [Symbol(mongoErrorContextSymbol)]: {} }
```
