### PR TITLE
Make Colors Change for Metric Boxes & Gauges

### DIFF
--- a/client/src/ui/ClassView.jsx
+++ b/client/src/ui/ClassView.jsx
@@ -140,6 +140,7 @@ export class ClassView extends Component {
                     <Gauge
                       rating={parseFloat(this.state.selectedClass.classRating)}
                       label="Overall"
+                      isOverall={true}
                     />
                   </div>
                   <div className="col-4 classview-gauge">
@@ -148,6 +149,7 @@ export class ClassView extends Component {
                         this.state.selectedClass.classDifficulty
                       )}
                       label="Difficulty"
+                      isOverall={false}
                     />
                   </div>
                   <div className="col-4 classview-gauge">
@@ -156,6 +158,7 @@ export class ClassView extends Component {
                         this.state.selectedClass.classWorkload
                       )}
                       label="Workload"
+                      isOverall={false}
                     />
                   </div>
                 </div>

--- a/client/src/ui/ClassViewNew.tsx
+++ b/client/src/ui/ClassViewNew.tsx
@@ -308,16 +308,25 @@ export default function ClassView() {
               }`}
             >
               <div className={styles.gauge}>
-                <Gauge rating={selectedClass!.classRating} label="Overall" />
+                <Gauge
+                  rating={selectedClass!.classRating}
+                  label="Overall"
+                  isOverall={true}
+                />
               </div>
               <div className={styles.gauge}>
                 <Gauge
                   rating={selectedClass.classDifficulty}
                   label="Difficulty"
+                  isOverall={false}
                 />
               </div>
               <div className={styles.gauge}>
-                <Gauge rating={selectedClass.classWorkload} label="Workload" />
+                <Gauge
+                  rating={selectedClass.classWorkload}
+                  label="Workload"
+                  isOverall={false}
+                />
               </div>
             </div>
             {/* leave a review button, only shown on smaller screens */}

--- a/client/src/ui/Form.jsx
+++ b/client/src/ui/Form.jsx
@@ -173,7 +173,7 @@ export default class Form extends Component {
       let isHovered = this.state[metric + " " + i] ? "boxHover" : "";
       boxes.push(<div className="metricBoxWrapper"
         onClick={() => this.clickMetricBox(metric, i)} onMouseEnter={() => this.handleBoxHoverEnter(metric, i)} onMouseLeave={() => this.handleBoxHoverLeave(metric, i)}>
-        <div id={metric + " " + i} className={this.state[metric] < i ? "metricBox inactiveBox " + isHovered : "metricBox activeBox"}></div>
+        <div id={metric + " " + i} className={this.state[metric] < i ? "metricBox inactiveBox" + isHovered : "metricBox activeBox"}></div>
         <p className={this.state[metric] < i ? "inactiveText" : "activeText"}>{i}</p>
 
       </div>)

--- a/client/src/ui/Gauge.tsx
+++ b/client/src/ui/Gauge.tsx
@@ -7,7 +7,6 @@ type GaugeProps = {
   rating: number | undefined;
   label: string;
   isOverall: boolean;
-  // add a field
 };
 
 type GaugeState = {
@@ -50,7 +49,7 @@ export default function Gauge({ rating, label, isOverall }: GaugeProps) {
     } else {
       setGaugeState({ color: "#000", rating: "-", percentage: 0.0 });
     }
-  }, [setGaugeState, rating]);
+  }, [setGaugeState, rating, isOverall]);
 
   return (
     <div className={styles.gaugeContainer}>

--- a/client/src/ui/Gauge.tsx
+++ b/client/src/ui/Gauge.tsx
@@ -6,6 +6,7 @@ import styles from "./css/Gauge.module.css";
 type GaugeProps = {
   rating: number | undefined;
   label: string;
+  // add a field
 };
 
 type GaugeState = {
@@ -25,6 +26,7 @@ export default function Gauge({ rating, label }: GaugeProps) {
     if (rating && !isNaN(rating)) {
       let percentage = 20 * rating; // rating is 1-5
       let color = `hsl(212, 100%, ${86 - percentage * 0.36}%)`;
+
       setGaugeState({
         percentage: percentage,
         color: color,

--- a/client/src/ui/Gauge.tsx
+++ b/client/src/ui/Gauge.tsx
@@ -28,13 +28,15 @@ export default function Gauge({ rating, label, isOverall }: GaugeProps) {
       let percentage = 20 * rating; // rating is 1-5
       let color;
 
-      let red = `hsla(4, 100%, 71%)`;
+      let red = `hsl(4, 100%, 71%)`;
       let yellow = `hsl(47, 94%, 58%)`;
       let green = `hsl(101, 64%, 43%)`;
 
-      if (0 <= rating && rating < 3) {
+      let ratingRounded = parseFloat(rating.toFixed(1));
+
+      if (0 <= ratingRounded && ratingRounded < 3) {
         color = isOverall ? red : green;
-      } else if (3 <= rating && rating < 4) {
+      } else if (3.0 <= ratingRounded && ratingRounded < 4) {
         color = yellow;
       } else {
         color = isOverall ? green : red;

--- a/client/src/ui/Gauge.tsx
+++ b/client/src/ui/Gauge.tsx
@@ -6,6 +6,7 @@ import styles from "./css/Gauge.module.css";
 type GaugeProps = {
   rating: number | undefined;
   label: string;
+  isOverall: boolean;
   // add a field
 };
 
@@ -15,7 +16,7 @@ type GaugeState = {
   rating: number | string;
 };
 
-export default function Gauge({ rating, label }: GaugeProps) {
+export default function Gauge({ rating, label, isOverall }: GaugeProps) {
   const [gaugeState, setGaugeState] = useState<GaugeState>({
     color: "#000",
     percentage: 0.0,
@@ -25,7 +26,19 @@ export default function Gauge({ rating, label }: GaugeProps) {
   useEffect(() => {
     if (rating && !isNaN(rating)) {
       let percentage = 20 * rating; // rating is 1-5
-      let color = `hsl(212, 100%, ${86 - percentage * 0.36}%)`;
+      let color;
+
+      let red = `hsla(4, 100%, 71%)`;
+      let yellow = `hsl(47, 94%, 58%)`;
+      let green = `hsl(101, 64%, 43%)`;
+
+      if (0 <= rating && rating < 3) {
+        color = isOverall ? red : green;
+      } else if (3 <= rating && rating < 4) {
+        color = yellow;
+      } else {
+        color = isOverall ? green : red;
+      }
 
       setGaugeState({
         percentage: percentage,

--- a/client/src/ui/PreviewCard.jsx
+++ b/client/src/ui/PreviewCard.jsx
@@ -186,15 +186,20 @@ export default class PreviewCard extends Component {
         {!this.props.transformGauges && (
           <div className="row gaugeHolder">
             <div className="col-lg-4 col-md-4 col-sm-4 col-4 remove-left-padding">
-              <Gauge rating={parseFloat(this.state.rating)} label="Overall" />
+              <Gauge rating={parseFloat(this.state.rating)} 
+              label="Overall"                      
+              isOverall={true} />
             </div>
             <div className="col-lg-4 col-md-4 col-sm-4 col-4 remove-left-padding">
-              <Gauge rating={parseFloat(this.state.diff)} label="Difficulty" />
+              <Gauge rating={parseFloat(this.state.diff)} 
+              label="Difficulty"                      
+              isOverall={false} />
             </div>
             <div className="col-lg-4 col-md-4 col-sm-4 col-4 remove-left-padding">
               <Gauge
                 rating={parseFloat(this.state.workload)}
                 label="Workload"
+                isOverall={false}
               />
             </div>
           </div>

--- a/client/src/ui/RatingInput.tsx
+++ b/client/src/ui/RatingInput.tsx
@@ -10,6 +10,7 @@ type RatingInputProps = {
   minLabel?: string;
   maxLabel?: string;
   className?: string;
+  isOverall: boolean;
 };
 
 /**
@@ -26,8 +27,10 @@ export default function RatingInput({
   minLabel,
   maxLabel,
   className,
+  isOverall,
 }: RatingInputProps) {
   const [hoverIndex, setHoverIndex] = useState(value - 1);
+  const [color, setColor] = useState<string>("");
 
   const buttonRefs = useMemo(
     () => Array.from({ length: maxRating }).map(() => React.createRef<any>()),
@@ -36,6 +39,10 @@ export default function RatingInput({
 
   useEffect(() => {
     setHoverIndex(value - 1);
+  }, [value]);
+
+  useEffect(() => {
+    setColor(getColor(value));
   }, [value]);
 
   function handleKeyDown({ key }: any) {
@@ -48,6 +55,16 @@ export default function RatingInput({
     }
   }
 
+  function getColor(index: number) {
+    if (0 <= index && index < 3) {
+      return isOverall ? "Red" : "Green";
+    } else if (3 <= index && index < 4) {
+      return "Yellow";
+    } else {
+      return isOverall ? "Green" : "Red";
+    }
+  }
+
   return (
     <div className={className} tabIndex={0} onKeyDown={handleKeyDown}>
       <label className={styles.ratingInputLabel}>{label}</label>
@@ -56,14 +73,26 @@ export default function RatingInput({
           <span
             className={styles.ratingUnit}
             key={`${name}-${i}`}
-            onMouseEnter={() => setHoverIndex(i)}
-            onMouseLeave={() => setHoverIndex(value - 1)}
+            onMouseEnter={() => {
+              setHoverIndex(i);
+              setColor(getColor(i));
+            }}
+            onMouseLeave={() => {
+              setHoverIndex(value - 1);
+              setColor(getColor(value - 1));
+            }}
           >
             <button
               ref={buttonRefs[i]}
               className={styles.ratingButton}
-              onClick={() => setValue(i + 1)}
-              onFocus={() => setValue(i + 1)}
+              onClick={() => {
+                setValue(i + 1);
+                setColor(getColor(value));
+              }}
+              onFocus={() => {
+                setValue(i + 1);
+                setColor(getColor(value));
+              }}
               tabIndex={-1}
             >
               <div
@@ -71,9 +100,12 @@ export default function RatingInput({
                   ${
                     i >= value &&
                     i < hoverIndex + 1 &&
-                    styles.ratingButtonPillHover
+                    styles["ratingButtonPillHover" + color]
                   }
-                  ${i < hoverIndex + 1 && styles.ratingButtonPillSelected}
+                  ${
+                    i < hoverIndex + 1 &&
+                    styles["ratingButtonPillSelected" + color]
+                  }
                 `}
               />
               {i + 1}

--- a/client/src/ui/RatingInput.tsx
+++ b/client/src/ui/RatingInput.tsx
@@ -39,9 +39,6 @@ export default function RatingInput({
 
   useEffect(() => {
     setHoverIndex(value - 1);
-  }, [value]);
-
-  useEffect(() => {
     setColor(getColor(value));
   }, [value]);
 
@@ -75,11 +72,11 @@ export default function RatingInput({
             key={`${name}-${i}`}
             onMouseEnter={() => {
               setHoverIndex(i);
-              setColor(getColor(i));
+              setColor(getColor(i + 1));
             }}
             onMouseLeave={() => {
               setHoverIndex(value - 1);
-              setColor(getColor(value - 1));
+              setColor(getColor(value));
             }}
           >
             <button
@@ -87,11 +84,11 @@ export default function RatingInput({
               className={styles.ratingButton}
               onClick={() => {
                 setValue(i + 1);
-                setColor(getColor(value));
+                setColor(getColor(i + 1));
               }}
               onFocus={() => {
                 setValue(i + 1);
-                setColor(getColor(value));
+                setColor(getColor(i + 1));
               }}
               tabIndex={-1}
             >

--- a/client/src/ui/ReviewForm.tsx
+++ b/client/src/ui/ReviewForm.tsx
@@ -36,11 +36,11 @@ export default function ReviewForm({
 }: ReviewFormProps) {
   const [overallRating, setOverallRating] = useState(value?.rating || 3);
   const [difficultyRating, setDifficultyRating] = useState(
-    value?.difficulty || 3,
+    value?.difficulty || 3
   );
   const [workloadRating, setWorkloadRating] = useState(value?.workload || 3);
   const [selectedProfessors, setSelectedProfessors] = useState<string[]>(
-    value?.professors || [],
+    value?.professors || []
   );
   const [isSelectedProfessorsInvalid, setIsSelectedProfessorsInvalid] =
     useState(false);
@@ -58,7 +58,7 @@ export default function ReviewForm({
 
   function isInputValid(): boolean {
     const regex = new RegExp(
-      /^(?=.*[A-Z0-9])[\w:;.,?$%*#@[\]!--{}/\\()"'/$ ]+$/i,
+      /^(?=.*[A-Z0-9])[\w:;.,?$%*#@[\]!--{}/\\()"'/$ ]+$/i
     );
     const isReviewTextValid =
       !isReviewCommentVisible || (!!reviewText && regex.test(reviewText));
@@ -84,7 +84,7 @@ export default function ReviewForm({
           onChange={(professors: any) => {
             setIsSelectedProfessorsInvalid(false);
             setSelectedProfessors(
-              professors?.map(({ value, label }: any) => value),
+              professors?.map(({ value, label }: any) => value)
             );
           }}
           isMulti
@@ -104,6 +104,7 @@ export default function ReviewForm({
           maxRating={5}
           minLabel="Not for me"
           maxLabel="Loved it"
+          isOverall={true}
         />
       </div>
       <div className={styles.ratingInput}>
@@ -115,6 +116,7 @@ export default function ReviewForm({
           maxRating={5}
           minLabel="Piece of cake"
           maxLabel="Challenging"
+          isOverall={false}
         />
       </div>
       <div className={styles.ratingInput}>
@@ -126,6 +128,7 @@ export default function ReviewForm({
           maxRating={5}
           minLabel="Not much"
           maxLabel="Lots of work"
+          isOverall={false}
         />
       </div>
       <div>

--- a/client/src/ui/css/RatingInput.module.css
+++ b/client/src/ui/css/RatingInput.module.css
@@ -39,6 +39,12 @@
   background-color: #0076ff;
 }
 
+/*
+Red: rgba(225, 117, 108, 1), #FF756C
+Yellow: rgba(248, 204, 48, 1), #F8CC30
+Green: rgba(83, 178, 39, 1), #53B227
+*/
+
 .ratingButtonPillSelectedRed {
   background-color: #FF756C;
 }
@@ -52,10 +58,13 @@
 }
 
 /*
+For hovering, use colors that are 50% opacity of normal colors
+
 Red: rgba(225, 117, 108, 0.5), #e1756c80
 Yellow: rgba(248, 204, 48, 0.5), #f8cc3080
 Green: rgba(83, 178, 39, 0.5), #53b22780
 */
+
 .ratingButtonPillHover {
   background-color: #b7d8ff;
 }

--- a/client/src/ui/css/RatingInput.module.css
+++ b/client/src/ui/css/RatingInput.module.css
@@ -39,8 +39,37 @@
   background-color: #0076ff;
 }
 
+.ratingButtonPillSelectedRed {
+  background-color: #FF756C;
+}
+
+.ratingButtonPillSelectedYellow {
+  background-color: #F8CC30;
+}
+
+.ratingButtonPillSelectedGreen {
+  background-color: #53B227;
+}
+
+/*
+Red: rgba(225, 117, 108, 0.5), #e1756c80
+Yellow: rgba(248, 204, 48, 0.5), #f8cc3080
+Green: rgba(83, 178, 39, 0.5), #53b22780
+*/
 .ratingButtonPillHover {
   background-color: #b7d8ff;
+}
+
+.ratingButtonPillHoverRed {
+  background-color: #e1756c80;
+}
+
+.ratingButtonPillHoverYellow {
+  background-color: #f8cc3080;
+}
+
+.ratingButtonPillHoverGreen {
+  background-color: #53b22780; 
 }
 
 .ratingMinMaxLabel {


### PR DESCRIPTION
### Summary <!-- Required -->

This PR implements different color scales in metric boxes and gauges. Colors are assigned based on these values:
![image](https://user-images.githubusercontent.com/75141596/166190973-18d3b9f5-799d-4938-91de-b2910185a5da.png)
Since Overall and Difficulty & Workload use different ranges, a new variable `isOverall` was added to `GaugeProps` and `RatingInputProps`. This `isOverall` is used along with the rating value to assign appropriate colors.

Here are 3 places with the reflected changes:
1. Gauges in class preview
![image](https://user-images.githubusercontent.com/75141596/166190740-eaf73505-7683-4f48-ba4e-10a2bbe1dda5.png)

2. Gauges in class view
![image](https://user-images.githubusercontent.com/75141596/166190841-62d983bc-1c75-4dab-b4c2-d7c593d57790.png)
![image](https://user-images.githubusercontent.com/75141596/166191379-5ab53cf3-4d42-44e3-95ec-da7444b387a4.png)
![image](https://user-images.githubusercontent.com/75141596/166191434-403628f7-8929-4230-b968-e49fe47f51c4.png)
![image](https://user-images.githubusercontent.com/75141596/166191503-79c5f7f6-9014-4fcb-985a-009206bd0d42.png)

3. Metric boxes in review form
![image](https://user-images.githubusercontent.com/75141596/166190269-4dfbdb27-6140-4651-90f2-efccec8048c2.png)

The color codes used are as following:
- Red: hsl(4, 100%, 71%), rgba(225, 117, 108, 1), #FF756C
- Yellow: hsl(47, 94%, 58%), rgba(248, 204, 48, 1), #F8CC30
- Green: hsl(101, 64%, 43%), rgba(83, 178, 39, 1), #53B227

For hovering for metric boxes, above colors with 50% opacity were used:
- Red: rgba(225, 117, 108, 0.5), #e1756c80
- Yellow: rgba(248, 204, 48, 0.5), #f8cc3080
- Green: rgba(83, 178, 39, 0.5), #53b22780

### Test Plan <!-- Required -->

tested locally to ensure the colors are changing correctly for different values

### Notes <!-- Optional -->

### Breaking Changes  <!-- Optional -->

none
