### PR TITLE
Reverting Reviews to Sticky

### DIFF
--- a/client/src/ui/css/ClassView.css
+++ b/client/src/ui/css/ClassView.css
@@ -10,7 +10,7 @@
 }
 
 .navbar-margin {
-  margin-top: 45px;
+  margin-top: 5px;
 }
 
 .classview-column-container {

--- a/client/src/ui/css/ClassView.module.css
+++ b/client/src/ui/css/ClassView.module.css
@@ -146,7 +146,7 @@
   background-color: #ffffff;
   padding: 20px;
   position: sticky;
-  top: 50px;
+  top: 10px;
 }
 
 .gaugeContainer {

--- a/client/src/ui/css/ClassView.module.css
+++ b/client/src/ui/css/ClassView.module.css
@@ -153,14 +153,14 @@
   width: 100%;
   background-color: #ffffff;
   height: 150px;
-  padding: 30px 5px;
+  padding: 0px 0px;
   display: flex;
   justify-content: space-between;
 }
 
 .gauge {
   height: 100%;
-  padding: 0 8px 0 0;
+  padding: 0 0px 0 0;
 }
 
 .startReviewButton {

--- a/client/src/ui/css/Form.css
+++ b/client/src/ui/css/Form.css
@@ -57,12 +57,12 @@
 .covidCheckboxLabel{
   position: relative;
   vertical-align: middle;
-  bottom: 1px;
+  bottom: 0px;
 }
 
 @media (max-width: 992px){
   .covidCheckboxLabel{
-    bottom: 2px;
+    bottom: 0px;
   }
 }
 
@@ -90,7 +90,7 @@
   .form{
     margin-left: 22px;
     margin-right: 22px;
-    margin-top: 25px;
+    margin-top: 0px;
     margin-bottom: 39px;
   }
 }
@@ -181,7 +181,7 @@
 }
 
 .form-professor-label{
-  padding-top:10px;
+  padding-top:0px;
 }
 
 @media (max-width: 992px) {
@@ -197,7 +197,7 @@
     font-style: normal;
     font-weight: normal;
     font-size: 15px;
-    line-height: 19px;
+    line-height: 0px;
     align-items: center;
     text-align: center;
     background: #0076FF;
@@ -231,9 +231,9 @@
 /* Form Select Styling */
 
 .form-select-alignment {
-  padding-top: 8px;
-  padding-left: 0;
-  padding-right: 0;
+  padding-top: 0px;
+  padding-left: 0px;
+  padding-right: 0px;
   width: 70% !important;
 }
 

--- a/client/src/ui/css/ReviewForm.module.css
+++ b/client/src/ui/css/ReviewForm.module.css
@@ -8,7 +8,7 @@
 }
 
 .selectProfessorLabel {
-  margin-top: 8px;
+  margin-top: 0px;
   font-family: "Source Sans Pro", sans-serif;
   font-size: 14px;
   color: #000000;
@@ -16,12 +16,12 @@
 }
 
 .ratingInput {
-  margin-top: 16px;
+  margin-top: 4px;
 }
 
 .reviewComment {
   width: 100%;
-  margin-top: 8px;
+  margin-top: 2px;
   font-family: "Source Sans Pro", sans-serif;
   font-size: 14px;
   color: #000000;
@@ -46,8 +46,8 @@
 }
 
 .covidCheckboxLabel {
-  margin-top: 16px;
-  margin-bottom: 16px;
+  margin-top: 4px;
+  margin-bottom: 6px;
 }
 
 .covidCheckboxLabelText {


### PR DESCRIPTION
### Summary <!-- Required -->

Work in Progress. 

This pull request is to revert the review form to not be sticky as currently on my_reviews_page, you need to scroll all the way down to the end of the reviews to submit a review of your own. 

### Test Plan <!-- Required -->

Testing will compose of using different screen sizes and mobile, (etc). 

![image](https://user-images.githubusercontent.com/32402949/195627037-24bcd549-a3d4-40b1-896c-07b92de02577.png)


### Linter Warnings <!-- Required -->

<!-- Please make sure that you are not adding linter warnings. Similarly, make sure that `yarn workspace client run` yields no warnings. -->

No added linter warnings. 